### PR TITLE
Swift: Implemented Serde renames and proper enum types

### DIFF
--- a/src/swift.rs
+++ b/src/swift.rs
@@ -45,7 +45,7 @@ fn swift_lit_type(lit: Option<&syn::Lit>) -> &'static str {
         Some(syn::Lit::Float(_)) => "Float",
         Some(syn::Lit::Bool(_)) => "Bool",
         Some(syn::Lit::Verbatim(_)) => " ERROR ",
-        None => "",
+        None => "String", // Should be used when we have a bare enum
     }
 }
 
@@ -162,7 +162,7 @@ fn write_struct_convenience_methods(w: &mut dyn Write, id: &Id, init_fields: &Ve
         w,
         "
 public extension {struct} {{
-\tconvenience init(data: Data) throws {{
+\tinit(data: Data) throws {{
 \t\tlet decoded = try JSONDecoder().decode({struct}.self, from: data)
 \t\tself.init({params})
 \t}}

--- a/src/typescript.rs
+++ b/src/typescript.rs
@@ -42,7 +42,7 @@ impl Language for TypeScript {
         Ok(())
     }
 
-    fn write_begin_enum(&mut self, w: &mut dyn Write, id: &Id) -> std::io::Result<()> {
+    fn write_begin_enum(&mut self, w: &mut dyn Write, id: &Id, _enum_type: Option<&syn::Lit>) -> std::io::Result<()> {
         writeln!(w, "export enum {} {{", id.original)?;
         Ok(())
     }

--- a/tests/swift_tests.rs
+++ b/tests/swift_tests.rs
@@ -3,11 +3,11 @@ use typeshare::swift;
 
 #[test]
 fn can_generate_simple_struct_with_a_comment() {
-	let mut out: Vec<u8> = Vec::new();
-	let mut lang = swift::Swift::new();
-	let mut g = Generator::new(&mut lang, &mut out);
+    let mut out: Vec<u8> = Vec::new();
+    let mut lang = swift::Swift::new();
+    let mut g = Generator::new(&mut lang, &mut out);
 
-	let source = "
+    let source = "
 /// This is a comment.
 pub struct Person {
 	pub name: String,
@@ -17,10 +17,10 @@ pub struct Person {
 }
    
 ";
-	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
-	let result = String::from_utf8(out).unwrap();
+    assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+    let result = String::from_utf8(out).unwrap();
 
-	let expected = "/// 
+    let expected = "/// 
 /// Generated
 /// 
 
@@ -43,17 +43,17 @@ public struct Person: Codable {
 
 ";
 
-	assert_eq!(expected, &result);
-	println!("{}", result);
+    assert_eq!(expected, &result);
+    println!("{}", result);
 }
 
 #[test]
 fn can_handle_serde_rename() {
-	let mut out: Vec<u8> = Vec::new();
-	let mut lang = swift::Swift::new();
-	let mut g = Generator::new(&mut lang, &mut out);
+    let mut out: Vec<u8> = Vec::new();
+    let mut lang = swift::Swift::new();
+    let mut g = Generator::new(&mut lang, &mut out);
 
-	let source = r##"
+    let source = r##"
 /// This is a comment.
 pub struct Person {
 	pub name: String,
@@ -65,10 +65,10 @@ pub struct Person {
 }
    
 "##;
-	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
-	let result = String::from_utf8(out).unwrap();
+    assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+    let result = String::from_utf8(out).unwrap();
 
-	let expected = "/// 
+    let expected = "/// 
 /// Generated
 /// 
 
@@ -91,17 +91,17 @@ public struct Person: Codable {
 
 ";
 
-	assert_eq!(expected, &result);
-	println!("{}", result);
+    assert_eq!(expected, &result);
+    println!("{}", result);
 }
 
 #[test]
 fn can_generate_simple_enum() {
-	let mut out: Vec<u8> = Vec::new();
-	let mut lang = swift::Swift::new();
-	let mut g = Generator::new(&mut lang, &mut out);
+    let mut out: Vec<u8> = Vec::new();
+    let mut lang = swift::Swift::new();
+    let mut g = Generator::new(&mut lang, &mut out);
 
-	let source = r##"
+    let source = r##"
 /// This is a comment.
 pub enum Colors {
 	Red = 0,
@@ -110,10 +110,10 @@ pub enum Colors {
 }
    
 "##;
-	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
-	let result = String::from_utf8(out).unwrap();
+    assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+    let result = String::from_utf8(out).unwrap();
 
-	let expected = "/// 
+    let expected = "/// 
 /// Generated
 /// 
 
@@ -128,6 +128,6 @@ public enum Colors: Int, Codable {
 
 ";
 
-	assert_eq!(expected, &result);
-	println!("{}", result);
+    assert_eq!(expected, &result);
+    println!("{}", result);
 }

--- a/tests/swift_tests.rs
+++ b/tests/swift_tests.rs
@@ -41,6 +41,14 @@ public struct Person: Codable {
 	}
 }
 
+
+public extension Person {
+	convenience init(data: Data) throws {
+		let decoded = try JSONDecoder().decode(Person.self, from: data)
+		self.init(name: decoded.name, age: decoded.age, info: decoded.info, emails: decoded.emails)
+	}
+}
+
 ";
 
     assert_eq!(expected, &result);
@@ -86,6 +94,14 @@ public struct Person: Codable {
 		self.age = age
 		self.extraSpecialFieldOne = extraSpecialFieldOne
 		self.extraSpecialFieldTwo = extraSpecialFieldTwo
+	}
+}
+
+
+public extension Person {
+	convenience init(data: Data) throws {
+		let decoded = try JSONDecoder().decode(Person.self, from: data)
+		self.init(name: decoded.name, age: decoded.age, extraSpecialFieldOne: decoded.extraSpecialFieldOne, extraSpecialFieldTwo: decoded.extraSpecialFieldTwo)
 	}
 }
 

--- a/tests/swift_tests.rs
+++ b/tests/swift_tests.rs
@@ -43,7 +43,7 @@ public struct Person: Codable {
 
 
 public extension Person {
-	convenience init(data: Data) throws {
+	init(data: Data) throws {
 		let decoded = try JSONDecoder().decode(Person.self, from: data)
 		self.init(name: decoded.name, age: decoded.age, info: decoded.info, emails: decoded.emails)
 	}
@@ -99,7 +99,7 @@ public struct Person: Codable {
 
 
 public extension Person {
-	convenience init(data: Data) throws {
+	init(data: Data) throws {
 		let decoded = try JSONDecoder().decode(Person.self, from: data)
 		self.init(name: decoded.name, age: decoded.age, extraSpecialFieldOne: decoded.extraSpecialFieldOne, extraSpecialFieldTwo: decoded.extraSpecialFieldTwo)
 	}
@@ -143,6 +143,43 @@ public enum Colors: Int, Codable {
 }
 
 ";
+
+    assert_eq!(expected, &result);
+    println!("{}", result);
+}
+
+#[test]
+fn can_generate_bare_string_enum() {
+    let mut out: Vec<u8> = Vec::new();
+    let mut lang = swift::Swift::new();
+    let mut g = Generator::new(&mut lang, &mut out);
+
+    let source = r##"
+/// This is a comment.
+pub enum Colors {
+	Red,
+	Blue,
+	Green,
+}
+   
+"##;
+    assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+    let result = String::from_utf8(out).unwrap();
+
+    let expected = r#"/// 
+/// Generated
+/// 
+
+import Foundation
+
+/// This is a comment.
+public enum Colors: String, Codable {
+	case Red = "Red"
+	case Blue = "Blue"
+	case Green = "Green"
+}
+
+"#;
 
     assert_eq!(expected, &result);
     println!("{}", result);

--- a/tests/swift_tests.rs
+++ b/tests/swift_tests.rs
@@ -1,0 +1,133 @@
+use typeshare::language::Generator;
+use typeshare::swift;
+
+#[test]
+fn can_generate_simple_struct_with_a_comment() {
+	let mut out: Vec<u8> = Vec::new();
+	let mut lang = swift::Swift::new();
+	let mut g = Generator::new(&mut lang, &mut out);
+
+	let source = "
+/// This is a comment.
+pub struct Person {
+	pub name: String,
+	pub age: u8,
+	pub info: Option<String>,
+	pub emails: Vec<String>,
+}
+   
+";
+	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+	let result = String::from_utf8(out).unwrap();
+
+	let expected = "/// 
+/// Generated
+/// 
+
+import Foundation
+
+/// This is a comment.
+public struct Person: Codable {
+	public let name: String
+	public let age: UInt8
+	public let info: String?
+	public let emails: [String]
+
+	public init(name: String, age: UInt8, info: String?, emails: [String]) {
+		self.name = name
+		self.age = age
+		self.info = info
+		self.emails = emails
+	}
+}
+
+";
+
+	assert_eq!(expected, &result);
+	println!("{}", result);
+}
+
+#[test]
+fn can_handle_serde_rename() {
+	let mut out: Vec<u8> = Vec::new();
+	let mut lang = swift::Swift::new();
+	let mut g = Generator::new(&mut lang, &mut out);
+
+	let source = r##"
+/// This is a comment.
+pub struct Person {
+	pub name: String,
+	pub age: u8,
+	#[serde(rename="extraSpecialFieldOne")]
+	pub extra_special_field1: i32,
+	#[serde(rename="extraSpecialFieldTwo")]
+	pub extra_special_field2: Option<Vec<String>>,
+}
+   
+"##;
+	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+	let result = String::from_utf8(out).unwrap();
+
+	let expected = "/// 
+/// Generated
+/// 
+
+import Foundation
+
+/// This is a comment.
+public struct Person: Codable {
+	public let name: String
+	public let age: UInt8
+	public let extraSpecialFieldOne: Int32
+	public let extraSpecialFieldTwo: [String]?
+
+	public init(name: String, age: UInt8, extraSpecialFieldOne: Int32, extraSpecialFieldTwo: [String]?) {
+		self.name = name
+		self.age = age
+		self.extraSpecialFieldOne = extraSpecialFieldOne
+		self.extraSpecialFieldTwo = extraSpecialFieldTwo
+	}
+}
+
+";
+
+	assert_eq!(expected, &result);
+	println!("{}", result);
+}
+
+#[test]
+fn can_generate_simple_enum() {
+	let mut out: Vec<u8> = Vec::new();
+	let mut lang = swift::Swift::new();
+	let mut g = Generator::new(&mut lang, &mut out);
+
+	let source = r##"
+/// This is a comment.
+pub enum Colors {
+	Red = 0,
+	Blue = 1,
+	Green = 2,
+}
+   
+"##;
+	assert!(g.process_source(source.to_string()).is_ok(), "must be able to process the source");
+	let result = String::from_utf8(out).unwrap();
+
+	let expected = "/// 
+/// Generated
+/// 
+
+import Foundation
+
+/// This is a comment.
+public enum Colors: Int, Codable {
+	case Red = 0
+	case Blue = 1
+	case Green = 2
+}
+
+";
+
+	assert_eq!(expected, &result);
+	println!("{}", result);
+}


### PR DESCRIPTION
This adds a test file similar to the Typescript one, implements the Serde renaming for the Swift output, and adds the proper type to the swift generated enums

Edit:  Added a convenience initializer from `Data` using `Codable`.