### PR TITLE
Correct append to prepend

### DIFF
--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -10,7 +10,7 @@ The behaviour of Typeshare can be customized by either passing options on the co
     (Required) The file path to which the generated definitions will be written.
 
 - `-s`, `--swift-prefix`
-    Specify a prefix that will be appended to type names when generating types in Swift. 
+    Specify a prefix that will be prepended to type names when generating types in Swift. 
 
 - `-M`, `--module-name`
     Specify the name of the Kotlin module for generated Kotlin source code. 


### PR DESCRIPTION
This is based off of the description in the documentation. Since this correction isnt based off of the source code (sorry, trying this PR out on gitpod.io since I'm away from my computer), it is possible that this correction should be reversed.

This is also a very small PR, I am happy if it goes in with another, more meaningful contribution.