### PR TITLE
Extract format so it can be changed per language

### DIFF
--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -101,10 +101,15 @@ pub trait Language {
                 "{}{}",
                 self.format_simple_type(base, generic_types)?,
                 (!parameters.is_empty())
-                    .then(|| format!("<{}>", parameters.into_iter().join(", ")))
+                    .then(|| self.format_generic_parameters(parameters))
                     .unwrap_or_default()
             ))
         }
+    }
+
+    /// Format generic parameters like <A, B, C>
+    fn format_generic_parameters(&self, parameters: Vec<String>) -> String {
+        format!("<{}>", parameters.into_iter().join(", "))
     }
 
     /// Format a base type that is classified as a SpecialRustType.


### PR DESCRIPTION
Right now, all supported languages format generic parameters into `<A, B, C>`.
By this change, we can introduce different format, like `[A, B, C]` for Scala.


