### PR TITLE
Rename typeshare-cli binary to `typeshare` on installation

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/1Password/typeshare"
 readme = "README.md"
 
+[[bin]]
+name = "typeshare"
+path = "src/main.rs"
+
 [features]
 go = []
 


### PR DESCRIPTION
This fixes #4.

Rather simple to solve, just had to add a `[[bin]]` entry to `cli/Cargo.toml`.