### PR TITLE
Update `typeshare-cli` to 1.0.1

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.0.0"
+version = "1.0.1"
 rust-version = "1.57"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"


### PR DESCRIPTION
This is a prerequisite to release patch version 1.0.1 for `typeshare-cli`.