### PR TITLE
Draft: Support date types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "clap_complete_command",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -170,9 +170,11 @@ fn main() {
             package: config.kotlin.package,
             module_name: config.kotlin.module_name,
             type_mappings: config.kotlin.type_mappings,
+            ..Default::default()
         }),
         Some("typescript") => Box::new(TypeScript {
             type_mappings: config.typescript.type_mappings,
+            ..Default::default()
         }),
         #[cfg(feature = "go")]
         Some("go") => Box::new(Go {

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -72,7 +72,7 @@ impl Language for Go {
                 self.format_type(rtype1, generic_types)?,
                 self.format_type(rtype2, generic_types)?
             ),
-            SpecialRustType::DateTime => todo!(),
+            SpecialRustType::DateTime => "Time".into(),
             SpecialRustType::Unit => "struct{}".into(),
             SpecialRustType::String => "string".into(),
             SpecialRustType::I8
@@ -101,7 +101,13 @@ impl Language for Go {
         )?;
         writeln!(w, "package {}", self.package)?;
         writeln!(w)?;
-        writeln!(w, "import \"encoding/json\"")?;
+        writeln!(
+            w,
+            r#"import (
+    "encoding/json"
+    "time"
+)"#
+        )?;
         writeln!(w)?;
         Ok(())
     }

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -72,6 +72,7 @@ impl Language for Go {
                 self.format_type(rtype1, generic_types)?,
                 self.format_type(rtype2, generic_types)?
             ),
+            SpecialRustType::DateTime => todo!(),
             SpecialRustType::Unit => "struct{}".into(),
             SpecialRustType::String => "string".into(),
             SpecialRustType::I8

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -44,7 +44,8 @@ impl Language for Kotlin {
                     self.format_type(rtype1, generic_types)?,
                     self.format_type(rtype2, generic_types)?
                 )
-            }
+            },
+            SpecialRustType::DateTime => "java.time.Instant".into(),
             SpecialRustType::Unit => "Unit".into(),
             SpecialRustType::String => "String".into(),
             // https://kotlinlang.org/docs/basic-types.html#integer-types
@@ -70,11 +71,19 @@ impl Language for Kotlin {
             writeln!(w, " */")?;
             writeln!(w)?;
             writeln!(w, "@file:NoLiveLiterals")?;
+            writeln!(w, "@file:UseSerializers(JavaInstantSerializer::class)")?;
             writeln!(w)?;
             writeln!(w, "package {}", self.package)?;
             writeln!(w)?;
             writeln!(w, "import androidx.compose.runtime.NoLiveLiterals")?;
             writeln!(w, "import kotlinx.serialization.*")?;
+            writeln!(w)?;
+            writeln!(w, r#"object JavaInstantSerializer : KSerializer<java.time.Instant> {{
+    override val descriptor = PrimitiveDescriptor("Instant", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: java.time.Instant) = encoder.encodeString(value)
+    override fun deserialize(decoder: Decoder): java.time.Instant = java.time.Instant.parse(decoder.decodeString())
+}}
+"# )?;
             writeln!(w)?;
         }
 

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -8,6 +8,7 @@ use crate::{
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{collections::HashMap, io::Write};
 
 /// All information needed for Kotlin type-code
@@ -19,6 +20,8 @@ pub struct Kotlin {
     pub module_name: String,
     /// Conversions from Rust type names to Kotlin type names.
     pub type_mappings: HashMap<String, String>,
+    /// Whether we've outputted a Date (requires custom serializer)
+    pub has_date: AtomicBool,
 }
 
 impl Language for Kotlin {
@@ -44,8 +47,11 @@ impl Language for Kotlin {
                     self.format_type(rtype1, generic_types)?,
                     self.format_type(rtype2, generic_types)?
                 )
-            },
-            SpecialRustType::DateTime => "java.time.Instant".into(),
+            }
+            SpecialRustType::DateTime => {
+                self.has_date.store(true, Ordering::SeqCst);
+                "java.time.Instant".into()
+            }
             SpecialRustType::Unit => "Unit".into(),
             SpecialRustType::String => "String".into(),
             // https://kotlinlang.org/docs/basic-types.html#integer-types
@@ -71,23 +77,33 @@ impl Language for Kotlin {
             writeln!(w, " */")?;
             writeln!(w)?;
             writeln!(w, "@file:NoLiveLiterals")?;
-            writeln!(w, "@file:UseSerializers(JavaInstantSerializer::class)")?;
             writeln!(w)?;
             writeln!(w, "package {}", self.package)?;
             writeln!(w)?;
             writeln!(w, "import androidx.compose.runtime.NoLiveLiterals")?;
-            writeln!(w, "import kotlinx.serialization.*")?;
-            writeln!(w)?;
-            writeln!(w, r#"object JavaInstantSerializer : KSerializer<java.time.Instant> {{
-    override val descriptor = PrimitiveDescriptor("Instant", PrimitiveKind.STRING)
-    override fun serialize(encoder: Encoder, value: java.time.Instant) = encoder.encodeString(value)
-    override fun deserialize(decoder: Decoder): java.time.Instant = java.time.Instant.parse(decoder.decodeString())
-}}
-"# )?;
             writeln!(w)?;
         }
 
         Ok(())
+    }
+
+    fn end_file(&self, w: &mut dyn Write) -> std::io::Result<()> {
+        if self.has_date.load(Ordering::SeqCst) {
+            writeln!(w, "import kotlinx.serialization.*")?;
+            writeln!(w)?;
+            writeln!(
+                w,
+                r#"object JavaInstantSerializer : KSerializer<java.time.Instant> {{
+    override val descriptor = PrimitiveDescriptor("Instant", PrimitiveKind.STRING)
+    override fun serialize(encoder: Encoder, value: java.time.Instant) = encoder.encodeString(value)
+    override fun deserialize(decoder: Decoder): java.time.Instant = java.time.Instant.parse(decoder.decodeString())
+}}
+"#
+            )?;
+            Ok(())
+        } else {
+            Ok(())
+        }
     }
 
     fn write_type_alias(&self, w: &mut dyn Write, ty: &RustTypeAlias) -> std::io::Result<()> {

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -130,6 +130,7 @@ impl Language for Swift {
                 self.format_type(rtype1, generic_types)?,
                 self.format_type(rtype2, generic_types)?
             ),
+            SpecialRustType::DateTime => "Date".into(),
             SpecialRustType::Unit => {
                 self.should_emit_codable_void.store(true, Ordering::SeqCst);
                 "CodableVoid".into()

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -38,6 +38,7 @@ impl Language for TypeScript {
                 },
                 self.format_type(rtype2, generic_types)?
             )),
+            SpecialRustType::DateTime => todo!(),
             SpecialRustType::Unit => Ok("undefined".into()),
             SpecialRustType::String => Ok("string".into()),
             SpecialRustType::I8

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -112,6 +112,8 @@ pub enum SpecialRustType {
     HashMap(Box<RustType>, Box<RustType>),
     /// Represents `Option<T>` from the standard library
     Option(Box<RustType>),
+    /// Represents chrono::DateTime<?> from chrono
+    DateTime,
     /// Represents `()`
     Unit,
     /// Represents `String` from the standard library
@@ -213,6 +215,7 @@ impl TryFrom<&syn::Type> for RustType {
                             params.next().unwrap().into(),
                         ))
                     }
+                    "DateTime" => RustType::Special(SpecialRustType::DateTime),
                     "str" | "String" => RustType::Special(SpecialRustType::String),
                     // Since we do not need to box types in other languages, we treat this type
                     // as its inner type.
@@ -311,7 +314,8 @@ impl SpecialRustType {
         match &self {
             Self::Vec(rty) | Self::Option(rty) => rty.contains_type(ty),
             Self::HashMap(rty1, rty2) => rty1.contains_type(ty) || rty2.contains_type(ty),
-            Self::Unit
+            Self::DateTime
+            | Self::Unit
             | Self::String
             | Self::I8
             | Self::I16
@@ -340,6 +344,7 @@ impl SpecialRustType {
             Self::Vec(_) => "Vec",
             Self::Option(_) => "Option",
             Self::HashMap(_, _) => "HashMap",
+            Self::DateTime => "DateTime",
             Self::String => "String",
             Self::Bool => "bool",
             Self::I8 => "i8",
@@ -365,7 +370,8 @@ impl SpecialRustType {
             Self::HashMap(rtype1, rtype2) => {
                 Box::new([rtype1.as_ref(), rtype2.as_ref()].into_iter())
             }
-            Self::Unit
+            Self::DateTime
+            | Self::Unit
             | Self::String
             | Self::I8
             | Self::I16


### PR DESCRIPTION
This is the initial pass at supporting DateTime types in Typeshare. The basic gist is to map a chrono::DateTime type to a language-relevant type. Additionally, it will emit serializers for DateTime types if they are used.

Closes #34 

## Todo
- [ ] Update existing snapshot tests reflecting the changes
- [ ] Add appropriate unit and snapshot tests

## Types used
| Language | Type |
|-----------|------|
| Kotlin | java.time.Instant |
| Swift | Date (Foundation) |
| TypeScript | Date (JS Global) |
| Go | time.Time |


## Sample Input Rust Code
```rs
use chrono::{DateTime, Utc};
use serde::{Deserialize, Serialize};
use typeshare::typeshare;

#[derive(Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
#[typeshare]
pub struct DateTimeTest {
    pub test: DateTime<Utc>,
    pub uwu: u16,
    pub iwi: i16,
}
```

## Example output

### Kotlin
`typeshare typeshare-tests/src --lang kotlin --output-file typeshare-tests/typeshare-output/test_def.kt`
```kt
@Serializable
data class DateTimeTest (
	var test: java.time.Instant,
	var uwu: UShort,
	var iwi: Short
)

// Emits serializer at end of file

import kotlinx.serialization.*

object JavaInstantSerializer : KSerializer<java.time.Instant> {
    override val descriptor = PrimitiveDescriptor("Instant", PrimitiveKind.STRING)
    override fun serialize(encoder: Encoder, value: java.time.Instant) = encoder.encodeString(value)
    override fun deserialize(decoder: Decoder): java.time.Instant = java.time.Instant.parse(decoder.decodeString())
}
```

### Swift
```swift
/*
 Generated by typeshare 1.0.0
 */

import Foundation

public struct DateTimeTest: Codable {
	public let test: Date /* Foundation's Date is already Codable */
	public let uwu: UInt16
	public let iwi: Int16

	public init(test: Date, uwu: UInt16, iwi: Int16) {
		self.test = test
		self.uwu = uwu
		self.iwi = iwi
	}
}
```

### Typescript
```ts
/*
 Generated by typeshare 1.0.0
*/

export interface DateTimeTest {
	test: Date;
	uwu: number;
	iwi: number;
}

// Can be passed to JSON.parse(str, reviver) to marshal the ISO 8601 date string into a Date object
// JSON.stringify will emit a string in the right format by default
export function TypeshareDateReviver(key, value): Date { return new Date(value); }
```

### Go
> I have the least experience in Go, and am unsure if extra serializers are needed here.
```go
// Code generated by typeshare 1.0.0. DO NOT EDIT.
package test

import (
    "encoding/json"
    "time"
)

type DateTimeTest struct {
	Test Time `json:"test"`
	Uwu int `json:"uwu"`
	Iwi int `json:"iwi"`
}
```