### PR TITLE
Updates path to contributing page

### DIFF
--- a/docs/src/usage/usage.md
+++ b/docs/src/usage/usage.md
@@ -20,7 +20,7 @@ The currently supported output languages are:
 - Go
 
 ---
-If your favourite language is not in this list, consider opening an issue to request it or try implementing it yourself! See our [contribution guidelines](./contribution.md) for more details.
+If your favourite language is not in this list, consider opening an issue to request it or try implementing it yourself! See our [contribution guidelines](../contributing.md) for more details.
 
 ---
 


### PR DESCRIPTION
The usage.md page link to contribution information was leading to a 404 instead of a valid page.  This change corrects the path and page name.