### PR TITLE
Fix tests when go is not enabled

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -135,6 +135,7 @@ mod test {
         assert_eq!(config.swift.type_mappings["DateTime"], "Date");
         assert_eq!(config.kotlin.type_mappings["DateTime"], "String");
         assert_eq!(config.typescript.type_mappings["DateTime"], "string");
+        #[cfg(feature = "go")]
         assert_eq!(config.go.type_mappings["DateTime"], "string");
     }
 


### PR DESCRIPTION
```bash
cargo test
cargo test --features go
```

The struct is defined with the `cfg` macro on the field, so makes sense to test it the same way.

```rust
/// The paramters that are used to configure the behaviour of typeshare
/// from the configuration file `typeshare.toml`
pub(crate) struct Config {
    pub swift: SwiftParams,
    pub typescript: TypeScriptParams,
    pub kotlin: KotlinParams,
    #[cfg(feature = "go")]
    pub go: GoParams,
}
```