### PR TITLE
Correct the command line options in the docs

### DIFF
--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -4,7 +4,7 @@ The behaviour of Typeshare can be customized by either passing options on the co
 
 ## Command Line Options
 
-- `-t`, `--type` 
+- `-l`, `--lang`
     (Required) The language you want your definitions to be generated in. Currently, this option can be set to either `kotlin`, `swift`, `go`, or `typescript`.
 - `-o`, `--output-file`
     (Required) The file path to which the generated definitions will be written.


### PR DESCRIPTION
`-l` works but `-t` doesn't. The interactive help says to use `-l`.

```
⬢[chris@toolbox figma-rust]$ typeshare -l typescript -o typescript.ts .
⬢[chris@toolbox figma-rust]$ typeshare -t typescript -o typescript.ts .
error: Found argument '-t' which wasn't expected, or isn't valid in this context

	If you tried to supply `-t` as a value rather than a flag, use `-- -t`

USAGE:
    typeshare [OPTIONS] [directories]...
    typeshare <SUBCOMMAND>

For more information try --help
⬢[chris@toolbox figma-rust]$ typeshare --help
typeshare 1.0.1
Command Line Tool for generating language files with typeshare

USAGE:
    typeshare [OPTIONS] [directories]...
    typeshare <SUBCOMMAND>

ARGS:
    <directories>...    Directories within which to recursively find and process rust files

OPTIONS:
    -c, --config-file <CONFIGFILENAME>
            Configuration file for typeshare

    -g, --generate-config-file
            Generates a configuration file based on the other options specified. The file will be
            written to typeshare.toml by default or to the file path specified by the --config-file
            option.

    -h, --help
            Print help information

    -j, --java-package <JAVAPACKAGE>
            JAVA package name

    -l, --lang <TYPE>
            Language of generated types [possible values: kotlin, swift, typescript]

    -m, --module-name <MODULENAME>
            Kotlin serializer module name

    -o, --output-file <output-file>
            File to write output to. mtime will be preserved if the file contents don't change

    -s, --swift-prefix <SWIFTPREFIX>
            Prefix for generated Swift types

    -V, --version
            Print version information

SUBCOMMANDS:
    completions    Generate shell completions
    help           Print this message or the help of the given subcommand(s)
```
