### PR TITLE
Empty structs are now represented as `object`s in Kotlin

### DIFF
--- a/core/data/tests/can_generate_algebraic_enum/output.kt
+++ b/core/data/tests/can_generate_algebraic_enum/output.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.*
 
 /// Struct comment
 @Serializable
-class ItemDetailsFieldValue
+object ItemDetailsFieldValue
 
 /// Enum comment
 @Serializable

--- a/core/data/tests/can_generate_empty_algebraic_enum/output.kt
+++ b/core/data/tests/can_generate_empty_algebraic_enum/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class AddressDetails
+object AddressDetails
 
 @Serializable
 sealed class Address {

--- a/core/data/tests/can_generate_simple_struct_with_a_comment/output.kt
+++ b/core/data/tests/can_generate_simple_struct_with_a_comment/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class Location
+object Location
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/can_generate_unit_structs/output.kt
+++ b/core/data/tests/can_generate_unit_structs/output.kt
@@ -10,5 +10,5 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class UnitStruct
+object UnitStruct
 

--- a/core/data/tests/can_handle_serde_rename/output.kt
+++ b/core/data/tests/can_handle_serde_rename/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class OtherType
+object OtherType
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/can_handle_serde_rename_on_top_level/output.kt
+++ b/core/data/tests/can_handle_serde_rename_on_top_level/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class OtherType
+object OtherType
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/generate_types/output.kt
+++ b/core/data/tests/generate_types/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class CustomType
+object CustomType
 
 @Serializable
 data class Types (

--- a/core/data/tests/generates_empty_structs_and_initializers/output.kt
+++ b/core/data/tests/generates_empty_structs_and_initializers/output.kt
@@ -10,5 +10,5 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class MyEmptyStruct
+object MyEmptyStruct
 

--- a/core/data/tests/test_algebraic_enum_case_name_support/output.kt
+++ b/core/data/tests/test_algebraic_enum_case_name_support/output.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class ItemDetailsFieldValue
+object ItemDetailsFieldValue
 
 @Serializable
 sealed class AdvancedColors {

--- a/core/data/tests/use_correct_decoded_variable_name/output.kt
+++ b/core/data/tests/use_correct_decoded_variable_name/output.kt
@@ -10,5 +10,5 @@ import androidx.compose.runtime.NoLiveLiterals
 import kotlinx.serialization.*
 
 @Serializable
-class MyEmptyStruct
+object MyEmptyStruct
 

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -103,7 +103,8 @@ impl Language for Kotlin {
         writeln!(w, "@Serializable")?;
 
         if rs.fields.is_empty() {
-            writeln!(w, "class {}\n", rs.id.renamed)?;
+            // If the struct has no fields, we can define it as an static object.
+            writeln!(w, "object {}\n", rs.id.renamed)?;
         } else {
             writeln!(
                 w,


### PR DESCRIPTION
Follow-up PR to #51.