### PR TITLE
`const` support

### DIFF
--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use crate::parser::ParsedData;
 use crate::rename::RenameExt;
-use crate::rust_types::{RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::Language,
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
@@ -117,6 +117,10 @@ impl Language for Go {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -1,5 +1,5 @@
 use super::Language;
-use crate::rust_types::{RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustTypeFormatError, SpecialRustType};
 use crate::{
     parser::remove_dash_from_identifier,
     rename::RenameExt,
@@ -96,6 +96,10 @@ impl Language for Kotlin {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -10,7 +10,7 @@ mod kotlin;
 mod swift;
 mod typescript;
 
-use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustType, RustTypeFormatError, SpecialRustType};
 pub use go::Go;
 pub use kotlin::Kotlin;
 pub use swift::Swift;
@@ -130,6 +130,15 @@ pub trait Language {
     /// type MyTypeAlias = String;
     /// ```
     fn write_type_alias(&self, _w: &mut dyn Write, _t: &RustTypeAlias) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Write a constant variable.
+    /// Example of a constant variable:
+    /// ```
+    /// const ANSWER_TO_EVERYTHING: u32 = 42;
+    /// ```
+    fn write_const(&self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
         Ok(())
     }
 

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -1,4 +1,4 @@
-use crate::rust_types::{RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::Language,
     parser::remove_dash_from_identifier,
@@ -193,6 +193,10 @@ impl Language for Swift {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,4 +1,4 @@
-use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustType, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::Language,
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
@@ -87,6 +87,10 @@ impl Language for TypeScript {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -412,17 +412,13 @@ fn parse_const(c: &ItemConst) -> Result<RustConst, ParseError> {
     } else {
         RustType::try_from(c.ty.as_ref())?
     } {
-        RustType::Special(SpecialRustType::HashMap(_, _)) => {
-            todo!()
-        }
-        RustType::Special(SpecialRustType::Vec(_)) => {
-            todo!()
-        }
-        RustType::Special(SpecialRustType::Option(_)) => {
-            todo!()
+        RustType::Special(SpecialRustType::HashMap(_, _))
+        | RustType::Special(SpecialRustType::Vec(_))
+        | RustType::Special(SpecialRustType::Option(_)) => {
+            return Err(ParseError::RustConstTypeInvalid);
         }
         RustType::Special(s) => s,
-        _ => todo!(),
+        _ => return Err(ParseError::RustConstTypeInvalid),
     };
     Ok(RustConst {
         id: get_ident(Some(&c.ident), &c.attrs, &None),

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -58,9 +58,10 @@ pub struct RustConst {
 /// boundary.
 #[derive(Debug, Clone)]
 pub enum RustConstExpr {
-    Int(i64),
+    Int(i128),
     Float(f64),
-    String(String)
+    Boolean(bool),
+    String(String),
 }
 
 /// Rust type alias.

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -41,6 +41,28 @@ pub struct RustStruct {
     pub decorators: HashMap<String, Vec<String>>,
 }
 
+/// Rust const variable.
+///
+/// Typeshare can only handle numeric and string constants.
+/// ```
+/// pub const MY_CONST: &str = "constant value";
+/// ```
+#[derive(Debug, Clone)]
+pub struct RustConst {
+    pub id: Id,
+    pub r#type: SpecialRustType,
+    pub expr: RustConstExpr,
+}
+
+/// A constant expression that can be shared via a constant variable across the typeshare
+/// boundary.
+#[derive(Debug, Clone)]
+pub enum RustConstExpr {
+    Int(i64),
+    Float(f64),
+    String(String)
+}
+
 /// Rust type alias.
 /// ```
 /// pub struct MasterPassword(String);


### PR DESCRIPTION
Closes #44.

This PR will allow the `typeshare` annotation to be used for `const` variables. This will copy the variable declaration into the output for the respective language.

For example:
```rs
const ANSWER_TO_EVERYTHING: u32 = 42;
const BEST_FILM: &str = "The Tree of Life";
``` 

This would become:
```ts
const ANSWER_TO_EVERYTHING = 42;
const BEST_FILM = "The Tree of Life";
```
```swift
class Constants {
  static let ANSWER_TO_EVERYTHING = 42
  static let BEST_FILM = "The Tree of Life"
}
```
```kt
const val ANSWER_TO_EVERYTHING = 42
const val BEST_FILM = "The Tree of Life"
```
```go
const ANSWER_TO_EVERYTHING = 42
const BEST_FILM = "The Tree of LIfe"
```


As of right now, this PR only supports integers, floats, and strings as constant types.