### PR TITLE
Only deploy documentation when merging a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,3 @@ jobs:
         with:
           command: clippy
           args: -- -D clippy::dbg_macro -D warnings -D missing_docs -F unused_must_use
-  deploy-docs:
-    name: Deploy Documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
-      - run: mdbook build docs
-      - uses: JamesIves/github-pages-deploy-action@4.1.7
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: docs/book # The folder the action should deploy.

--- a/.github/workflows/docdeploy.yml
+++ b/.github/workflows/docdeploy.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Deploy Documentation
+
+jobs:
+  deploy-docs:
+    name: Deploy Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+      - run: mdbook build docs
+      - uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/book # The folder the action should deploy.


### PR DESCRIPTION
We deploy documentation in every CI pipeline, which is erroneous. It should only run when we're adding new commits to `main`.