### PR TITLE
Rework the attribute parser to use `syn`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/1Password/typeshare"
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1.0", features = ["full", "parsing"] }
+syn = { version = "1.0", features = ["full"] }
 thiserror = "1"
 itertools = "0.10"
 lazy_format = "1.8"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/1Password/typeshare"
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1.0", features = ["full"] }
+syn = { version = "1.0", features = ["full", "parsing"] }
 thiserror = "1"
 itertools = "0.10"
 lazy_format = "1.8"

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -172,7 +172,7 @@ impl Go {
                         write_comments(w, 1, &variant_shared.comments)?;
                         write!(
                             w,
-                            "\t{}{} {} = \"{}\"",
+                            "\t{}{} {} = {:?}",
                             self.acronyms_to_uppercase(&shared.id.original),
                             self.acronyms_to_uppercase(&variant_shared.id.original),
                             self.acronyms_to_uppercase(&shared.id.original),
@@ -295,7 +295,7 @@ impl Go {
                     write_comments(w, 1, &v.shared().comments)?;
                     writeln!(
                         w,
-                        "\t{} {} = \"{}\"",
+                        "\t{} {} = {:?}",
                         variant_type_const,
                         variant_key_type,
                         &v.shared().id.original
@@ -307,7 +307,7 @@ impl Go {
                 writeln!(w, "type {} struct{{ ", struct_name)?;
                 writeln!(
                     w,
-                    "\t{} {} `json:\"{}\"`",
+                    "\t{} {} `json:{:?}`",
                     self.format_field_name(tag_key.to_string(), true),
                     variant_key_type,
                     tag_key,
@@ -385,6 +385,8 @@ func ({short_name} {full_name}) MarshalJSON() ([]byte, error) {{
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         let go_type = self.acronyms_to_uppercase(&type_name);
         let is_optional = field.ty.is_optional() || field.has_default;
+        let formatted_renamed_id = format!("{:?}", &field.id.renamed);
+        let renamed_id = &formatted_renamed_id[1..formatted_renamed_id.len() - 1];
         writeln!(
             w,
             "\t{} {}{} `json:\"{}{}\"`",
@@ -393,7 +395,7 @@ func ({short_name} {full_name}) MarshalJSON() ([]byte, error) {{
                 .then(|| "*")
                 .unwrap_or_default(),
             go_type,
-            &field.id.renamed,
+            renamed_id,
             option_symbol(is_optional),
         )?;
 

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -181,10 +181,10 @@ impl Kotlin {
             RustEnum::Unit(shared) => {
                 for v in &shared.variants {
                     self.write_comments(w, 1, &v.shared().comments)?;
-                    writeln!(w, "\t@SerialName(\"{}\")", &v.shared().id.renamed)?;
+                    writeln!(w, "\t@SerialName({:?})", &v.shared().id.renamed)?;
                     writeln!(
                         w,
-                        "\t{}(\"{}\"),",
+                        "\t{}({:?}),",
                         &v.shared().id.original,
                         v.shared().id.renamed
                     )?;
@@ -303,7 +303,7 @@ impl Kotlin {
     ) -> std::io::Result<()> {
         self.write_comments(w, 1, &f.comments)?;
         if requires_serial_name {
-            writeln!(w, "\t@SerialName(\"{}\")", &f.id.renamed)?;
+            writeln!(w, "\t@SerialName({:?})", &f.id.renamed)?;
         }
         let ty = self
             .format_type(&f.ty, generic_types)

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -451,7 +451,7 @@ impl Swift {
                         // We do need to handle renaming
                         writeln!(
                             w,
-                            "\tcase {} = \"{}\"",
+                            "\tcase {} = {:?}",
                             swift_keyword_aware_rename(&variant_name),
                             &v.shared().id.renamed
                         )?;

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -155,7 +155,7 @@ impl TypeScript {
                 RustEnumVariant::Unit(shared) => {
                     writeln!(w)?;
                     self.write_comments(w, 1, &shared.comments)?;
-                    write!(w, "\t{} = \"{}\",", shared.id.original, &shared.id.renamed)
+                    write!(w, "\t{} = {:?},", shared.id.original, &shared.id.renamed)
                 }
                 _ => unreachable!(),
             }),
@@ -172,7 +172,7 @@ impl TypeScript {
                 match v {
                     RustEnumVariant::Unit(shared) => write!(
                         w,
-                        "\t| {{ {}: \"{}\", {}?: undefined }}",
+                        "\t| {{ {}: {:?}, {}?: undefined }}",
                         tag_key, shared.id.renamed, content_key
                     ),
                     RustEnumVariant::Tuple { ty, shared } => {
@@ -181,7 +181,7 @@ impl TypeScript {
                             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                         write!(
                             w,
-                            "\t| {{ {}: \"{}\", {}{}: {} }}",
+                            "\t| {{ {}: {:?}, {}{}: {} }}",
                             tag_key,
                             shared.id.renamed,
                             content_key,
@@ -192,7 +192,7 @@ impl TypeScript {
                     RustEnumVariant::AnonymousStruct { fields, shared } => {
                         writeln!(
                             w,
-                            "\t| {{ {}: \"{}\", {}: {{",
+                            "\t| {{ {}: {:?}, {}: {{",
                             tag_key, shared.id.renamed, content_key
                         )?;
 
@@ -264,7 +264,7 @@ impl TypeScript {
 
 fn typescript_property_aware_rename(name: &str) -> String {
     if name.chars().any(|c| c == '-') {
-        return format!("\"{}\"", name);
+        return format!("{:?}", name);
     }
     name.to_string()
 }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -461,13 +461,13 @@ fn literal_as_string(lit: syn::Lit) -> Option<String> {
 fn get_typeshare_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Option<syn::Lit> {
     attrs
         .iter()
-        .map(|attr| {
+        .flat_map(|attr| {
             get_typeshare_meta_items(attr)
                 .iter()
                 .filter_map(|arg| match arg {
                     NestedMeta::Meta(Meta::NameValue(name_value)) => {
                         if let Some(ident) = name_value.path.get_ident() {
-                            if ident.to_string() == name {
+                            if *ident == name {
                                 Some(name_value.lit.clone())
                             } else {
                                 None
@@ -480,20 +480,19 @@ fn get_typeshare_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> O
                 })
                 .collect::<Vec<_>>()
         })
-        .flatten()
         .next()
 }
 
 fn get_serde_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Option<syn::Lit> {
     attrs
         .iter()
-        .map(|attr| {
+        .flat_map(|attr| {
             get_serde_meta_items(attr)
                 .iter()
                 .filter_map(|arg| match arg {
                     NestedMeta::Meta(Meta::NameValue(name_value)) => {
                         if let Some(ident) = name_value.path.get_ident() {
-                            if ident.to_string() == name {
+                            if *ident == name {
                                 Some(name_value.lit.clone())
                             } else {
                                 None
@@ -506,7 +505,6 @@ fn get_serde_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Optio
                 })
                 .collect::<Vec<_>>()
         })
-        .flatten()
         .next()
 }
 
@@ -615,7 +613,7 @@ fn serde_default(attrs: &[syn::Attribute]) -> bool {
 // TODO: for now, this is a workaround until we can integrate serde_derive_internal
 // into our parser.
 pub fn get_serde_meta_items(attr: &syn::Attribute) -> Vec<NestedMeta> {
-    if attr.path.get_ident().is_none() || attr.path.get_ident().unwrap().to_string() != SERDE {
+    if attr.path.get_ident().is_none() || *attr.path.get_ident().unwrap() != SERDE {
         return Vec::default();
     }
 
@@ -626,7 +624,7 @@ pub fn get_serde_meta_items(attr: &syn::Attribute) -> Vec<NestedMeta> {
 }
 
 pub fn get_typeshare_meta_items(attr: &syn::Attribute) -> Vec<NestedMeta> {
-    if attr.path.get_ident().is_none() || attr.path.get_ident().unwrap().to_string() != TYPESHARE {
+    if attr.path.get_ident().is_none() || *attr.path.get_ident().unwrap() != TYPESHARE {
         return Vec::default();
     }
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -458,10 +458,10 @@ fn literal_as_string(lit: syn::Lit) -> Option<String> {
     }
 }
 
-fn get_typeshare_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Option<syn::Lit> {
+fn get_typeshare_name_value_meta_items<'a>(attrs: &'a [syn::Attribute], name: &'a str) -> impl Iterator<Item=syn::Lit> + 'a {
     attrs
         .iter()
-        .flat_map(|attr| {
+        .flat_map(move |attr| {
             get_typeshare_meta_items(attr)
                 .iter()
                 .filter_map(|arg| match arg {
@@ -480,13 +480,12 @@ fn get_typeshare_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> O
                 })
                 .collect::<Vec<_>>()
         })
-        .next()
 }
 
-fn get_serde_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Option<syn::Lit> {
+fn get_serde_name_value_meta_items<'a>(attrs: &'a [syn::Attribute], name: &'a str) -> impl Iterator<Item=syn::Lit> + 'a {
     attrs
         .iter()
-        .flat_map(|attr| {
+        .flat_map(move |attr| {
             get_serde_meta_items(attr)
                 .iter()
                 .filter_map(|arg| match arg {
@@ -505,72 +504,35 @@ fn get_serde_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Optio
                 })
                 .collect::<Vec<_>>()
         })
-        .next()
 }
 
 fn get_serialized_as_type(attrs: &[syn::Attribute]) -> Option<String> {
-    get_typeshare_name_value_meta_item(attrs, "serialized_as").and_then(literal_as_string)
+    get_typeshare_name_value_meta_items(attrs, "serialized_as").next().and_then(literal_as_string)
 }
 
 fn get_field_type_override(attrs: &[syn::Attribute]) -> Option<String> {
-    get_typeshare_name_value_meta_item(attrs, "serialized_as").and_then(literal_as_string)
+    get_typeshare_name_value_meta_items(attrs, "serialized_as").next().and_then(literal_as_string)
 }
 
 /// Checks the struct or enum for decorators like `#[typeshare(swift = "Codable, Equatable")]`
 /// Takes a slice of `syn::Attribute`, returns a `HashMap<language, Vec<decoration_words>>`, where `language` and `decoration_words` are `String`s
 fn get_decorators(attrs: &[syn::Attribute]) -> HashMap<String, Vec<String>> {
-    // delimiting const strings to split apart the decorators by language
-    const SWIFT_PREFIX: &str = r##"swift = ""##;
-    const SUFFIX: &str = r##"""##;
 
     // The resulting HashMap, Key is the language, and the value is a vector of decorators words that will be put onto structures
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
 
-    // first go through the attributes and only work over the top level `#[typeshare...]`
-    for a in attrs {
-        if let Some(segment) = a.path.segments.iter().next() {
-            if segment.ident != Ident::new("typeshare", Span::call_site()) {
-                continue;
-            }
+    for value in get_typeshare_name_value_meta_items(attrs, "swift").filter_map(literal_as_string) {
+        let decorators: Vec<String> = value
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .collect();
 
-            // get the attribute as a string
-            let attr_as_string = a.tokens.to_string();
-            // parse the interior attributes, this basically removes the beginning and ending parentheses and
-            // splits by " , " which is the expected output of `syn`'s `tokens.to_string()`
-            // if there are interior attributes we should continue to parse, if not skip this attribute
-            let values = match parse_attr(&attr_as_string) {
-                Some(v) => v,
-                None => {
-                    continue;
-                }
-            };
-
-            // Now for each value of the interior attribute check if the value ends in '"' if not we do not have an assignment
-            // and we should just carry on
-            for v in values {
-                if !v.ends_with(SUFFIX) {
-                    continue;
-                }
-
-                // Using the swift const, check if we have a swift attribute and parse by getting the values and trimming (just in case whitespace is odd)
-                if v.starts_with(SWIFT_PREFIX) {
-                    let decorators: Vec<String> = remove_prefix_suffix(v, SWIFT_PREFIX, SUFFIX)
-                        .to_string()
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .collect();
-
-                    // lastly, get the entry in the hashmap output and extend the value, or insert what we have already found
-                    let decs = out.entry("swift".to_string()).or_insert_with(Vec::new);
-                    decs.extend(decorators);
-                    // Sorting so all the added decorators will be after the normal ([`String`], `Codable`) in alphabetical order
-                    decs.sort_unstable();
-                    decs.dedup(); //removing any duplicates just in case
-
-                    continue;
-                }
-            }
-        }
+        // lastly, get the entry in the hashmap output and extend the value, or insert what we have already found
+        let decs = out.entry("swift".to_string()).or_insert_with(Vec::new);
+        decs.extend(decorators);
+        // Sorting so all the added decorators will be after the normal ([`String`], `Codable`) in alphabetical order
+        decs.sort_unstable();
+        decs.dedup(); //removing any duplicates just in case
     }
 
     //return our hashmap mapping of language -> Vec<decorators>
@@ -578,19 +540,19 @@ fn get_decorators(attrs: &[syn::Attribute]) -> HashMap<String, Vec<String>> {
 }
 
 fn get_tag_key(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_item(attrs, "tag").and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "tag").next().and_then(literal_as_string)
 }
 
 fn get_content_key(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_item(attrs, "content").and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "content").next().and_then(literal_as_string)
 }
 
 fn serde_rename(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_item(attrs, "rename").and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "rename").next().and_then(literal_as_string)
 }
 
 fn serde_rename_all(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_item(attrs, "rename_all").and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "rename_all").next().and_then(literal_as_string)
 }
 
 fn serde_default(attrs: &[syn::Attribute]) -> bool {
@@ -655,19 +617,6 @@ fn is_skipped(attrs: &[syn::Attribute]) -> bool {
 }
 
 #[deprecated]
-fn parse_attr(attr: &str) -> Option<Vec<&str>> {
-    const ATTR_PREFIX: &str = "(";
-    const ATTR_SUFFIX: &str = ")";
-
-    if attr.starts_with(ATTR_PREFIX) && attr.ends_with(ATTR_SUFFIX) {
-        let attr = remove_prefix_suffix(attr, ATTR_PREFIX, ATTR_SUFFIX);
-        return Some(attr.split(" , ").collect());
-    }
-
-    None
-}
-
-#[deprecated]
 pub(crate) fn remove_prefix_suffix<'a>(
     src: &'a str,
     prefix: &'static str,
@@ -676,23 +625,6 @@ pub(crate) fn remove_prefix_suffix<'a>(
     src.strip_prefix(prefix)
         .and_then(|src| src.strip_suffix(suffix))
         .map_or(src, |src| src.trim())
-}
-
-#[test]
-fn test_serde_parse_attr() {
-    let expected = Some(vec![r#"tag = "type", content = "content""#]);
-
-    assert_eq!(
-        parse_attr(r#"( tag = "type", content = "content" )"#),
-        expected,
-        "Expected to parse serde attribute correctly with spaces"
-    );
-
-    assert_eq!(
-        parse_attr(r#"(tag = "type", content = "content")"#),
-        expected,
-        "Expected to parse serde attribute correctly without spaces",
-    );
 }
 
 #[test]

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -458,74 +458,76 @@ fn literal_as_string(lit: syn::Lit) -> Option<String> {
     }
 }
 
-fn get_typeshare_name_value_meta_items<'a>(attrs: &'a [syn::Attribute], name: &'a str) -> impl Iterator<Item=syn::Lit> + 'a {
-    attrs
-        .iter()
-        .flat_map(move |attr| {
-            get_typeshare_meta_items(attr)
-                .iter()
-                .filter_map(|arg| match arg {
-                    NestedMeta::Meta(Meta::NameValue(name_value)) => {
-                        if let Some(ident) = name_value.path.get_ident() {
-                            if *ident == name {
-                                Some(name_value.lit.clone())
-                            } else {
-                                None
-                            }
+fn get_typeshare_name_value_meta_items<'a>(
+    attrs: &'a [syn::Attribute],
+    name: &'a str,
+) -> impl Iterator<Item = syn::Lit> + 'a {
+    attrs.iter().flat_map(move |attr| {
+        get_typeshare_meta_items(attr)
+            .iter()
+            .filter_map(|arg| match arg {
+                NestedMeta::Meta(Meta::NameValue(name_value)) => {
+                    if let Some(ident) = name_value.path.get_ident() {
+                        if *ident == name {
+                            Some(name_value.lit.clone())
                         } else {
                             None
                         }
+                    } else {
+                        None
                     }
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-        })
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    })
 }
 
-fn get_serde_name_value_meta_items<'a>(attrs: &'a [syn::Attribute], name: &'a str) -> impl Iterator<Item=syn::Lit> + 'a {
-    attrs
-        .iter()
-        .flat_map(move |attr| {
-            get_serde_meta_items(attr)
-                .iter()
-                .filter_map(|arg| match arg {
-                    NestedMeta::Meta(Meta::NameValue(name_value)) => {
-                        if let Some(ident) = name_value.path.get_ident() {
-                            if *ident == name {
-                                Some(name_value.lit.clone())
-                            } else {
-                                None
-                            }
+fn get_serde_name_value_meta_items<'a>(
+    attrs: &'a [syn::Attribute],
+    name: &'a str,
+) -> impl Iterator<Item = syn::Lit> + 'a {
+    attrs.iter().flat_map(move |attr| {
+        get_serde_meta_items(attr)
+            .iter()
+            .filter_map(|arg| match arg {
+                NestedMeta::Meta(Meta::NameValue(name_value)) => {
+                    if let Some(ident) = name_value.path.get_ident() {
+                        if *ident == name {
+                            Some(name_value.lit.clone())
                         } else {
                             None
                         }
+                    } else {
+                        None
                     }
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-        })
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    })
 }
 
 fn get_serialized_as_type(attrs: &[syn::Attribute]) -> Option<String> {
-    get_typeshare_name_value_meta_items(attrs, "serialized_as").next().and_then(literal_as_string)
+    get_typeshare_name_value_meta_items(attrs, "serialized_as")
+        .next()
+        .and_then(literal_as_string)
 }
 
 fn get_field_type_override(attrs: &[syn::Attribute]) -> Option<String> {
-    get_typeshare_name_value_meta_items(attrs, "serialized_as").next().and_then(literal_as_string)
+    get_typeshare_name_value_meta_items(attrs, "serialized_as")
+        .next()
+        .and_then(literal_as_string)
 }
 
 /// Checks the struct or enum for decorators like `#[typeshare(swift = "Codable, Equatable")]`
 /// Takes a slice of `syn::Attribute`, returns a `HashMap<language, Vec<decoration_words>>`, where `language` and `decoration_words` are `String`s
 fn get_decorators(attrs: &[syn::Attribute]) -> HashMap<String, Vec<String>> {
-
     // The resulting HashMap, Key is the language, and the value is a vector of decorators words that will be put onto structures
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
 
     for value in get_typeshare_name_value_meta_items(attrs, "swift").filter_map(literal_as_string) {
-        let decorators: Vec<String> = value
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .collect();
+        let decorators: Vec<String> = value.split(',').map(|s| s.trim().to_string()).collect();
 
         // lastly, get the entry in the hashmap output and extend the value, or insert what we have already found
         let decs = out.entry("swift".to_string()).or_insert_with(Vec::new);
@@ -540,19 +542,27 @@ fn get_decorators(attrs: &[syn::Attribute]) -> HashMap<String, Vec<String>> {
 }
 
 fn get_tag_key(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_items(attrs, "tag").next().and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "tag")
+        .next()
+        .and_then(literal_as_string)
 }
 
 fn get_content_key(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_items(attrs, "content").next().and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "content")
+        .next()
+        .and_then(literal_as_string)
 }
 
 fn serde_rename(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_items(attrs, "rename").next().and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "rename")
+        .next()
+        .and_then(literal_as_string)
 }
 
 fn serde_rename_all(attrs: &[syn::Attribute]) -> Option<String> {
-    get_serde_name_value_meta_items(attrs, "rename_all").next().and_then(literal_as_string)
+    get_serde_name_value_meta_items(attrs, "rename_all")
+        .next()
+        .and_then(literal_as_string)
 }
 
 fn serde_default(attrs: &[syn::Attribute]) -> bool {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -6,7 +6,6 @@ use crate::{
     },
 };
 use proc_macro2::{Ident, Span};
-use quote::ToTokens;
 use std::{collections::HashMap, convert::TryFrom};
 use syn::{Fields, ItemEnum, ItemStruct, ItemType};
 use syn::{GenericParam, Meta, NestedMeta};
@@ -495,10 +494,6 @@ fn get_serde_name_value_meta_item(attrs: &[syn::Attribute], name: &str) -> Optio
                     NestedMeta::Meta(Meta::NameValue(name_value)) => {
                         if let Some(ident) = name_value.path.get_ident() {
                             if ident.to_string() == name {
-                                println!(
-                                    "meta name-value! {:?}",
-                                    name_value.to_token_stream().to_string()
-                                );
                                 Some(name_value.lit.clone())
                             } else {
                                 None
@@ -661,80 +656,7 @@ fn is_skipped(attrs: &[syn::Attribute]) -> bool {
     })
 }
 
-/*
-    Process attributes and return value of the matching attribute, if found.
-    ```
-    [
-    Attribute
-        {
-            pound_token: Pound,
-            style: Outer,
-            bracket_token: Bracket,
-            path: Path {
-                leading_colon: None,
-                segments: [
-                    PathSegment { ident: Ident(doc), arguments: None }
-                ]
-            },
-            tts: TokenStream [
-                Punct { op: '=', spacing: Alone },
-                Literal { lit: " This is a comment." }]
-        },
-
-    Attribute
-        {
-            pound_token: Pound,
-            style: Outer,
-            bracket_token: Bracket,
-            path: Path {
-                leading_colon: None,
-                segments: [
-                    PathSegment { ident: Ident(serde), arguments: None }
-                ]
-            }
-            tts: TokenStream [
-                Group {
-                    delimiter: Parenthesis,
-                    stream: TokenStream [
-                        Ident { sym: default },
-                        Punct { op: ',', spacing: Alone },
-                        Ident { sym: rename_all },
-                        Punct { op: '=', spacing: Alone },
-                        Literal { lit: "camelCase" }
-                    ]
-                }
-            ]
-        }
-    ]
-    ```
-*/
 #[deprecated]
-fn attr_value(
-    ident: &str,
-    attrs: &[syn::Attribute],
-    prefix: &'static str,
-    suffix: &'static str,
-) -> Option<String> {
-    for a in attrs {
-        if let Some(segment) = a.path.segments.iter().next() {
-            if segment.ident != Ident::new(ident, Span::call_site()) {
-                continue;
-            }
-
-            let attr_as_string = a.tokens.to_string();
-            let values = parse_attr(&attr_as_string)?;
-
-            for v in values {
-                if v.starts_with(prefix) && v.ends_with(suffix) {
-                    return Some(remove_prefix_suffix(v, prefix, suffix).to_string());
-                }
-            }
-        }
-    }
-
-    None
-}
-
 fn parse_attr(attr: &str) -> Option<Vec<&str>> {
     const ATTR_PREFIX: &str = "(";
     const ATTR_SUFFIX: &str = ")";


### PR DESCRIPTION
Instead of parsing interior attribute tokens as a string, we now handle them as a list of `syn::NestedMeta`, similar to how serde parses their attributes. This should be a much more robust and flexible way to parse attributes going forward. Eventually, our serde parsing logic should be swapped out for direct calls to `serde_derive_internal`'s API.