### PR TITLE
Changed supported languages from `String` to `enum`

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,7 +11,7 @@ use std::{fs, path::Path};
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
-    language::{Kotlin, Language, Swift, TypeScript},
+    language::{Kotlin, Language, SupportedLanguage, Swift, TypeScript},
     parser::ParsedData,
 };
 
@@ -156,33 +156,36 @@ fn main() {
         return;
     }
 
-    let language_type = options.value_of(ARG_TYPE);
     let mut directories = options.values_of("directories").unwrap();
     let outfile = Path::new(options.value_of(ARG_OUTPUT_FILE).unwrap());
+    let language_type = options
+        .value_of(ARG_TYPE)
+        .map(|lang| lang.parse().ok())
+        .and_then(|parsed| parsed);
 
     let mut lang: Box<dyn Language> = match language_type {
-        Some("swift") => Box::new(Swift {
+        Some(SupportedLanguage::Swift) => Box::new(Swift {
             prefix: config.swift.prefix,
             type_mappings: config.swift.type_mappings,
             default_decorators: config.swift.default_decorators,
             ..Default::default()
         }),
-        Some("kotlin") => Box::new(Kotlin {
+        Some(SupportedLanguage::Kotlin) => Box::new(Kotlin {
             package: config.kotlin.package,
             module_name: config.kotlin.module_name,
             type_mappings: config.kotlin.type_mappings,
         }),
-        Some("typescript") => Box::new(TypeScript {
+        Some(SupportedLanguage::TypeScript) => Box::new(TypeScript {
             type_mappings: config.typescript.type_mappings,
         }),
         #[cfg(feature = "go")]
-        Some("go") => Box::new(Go {
+        Some(SupportedLanguage::Go) => Box::new(Go {
             package: config.go.package,
             type_mappings: config.go.type_mappings,
             uppercase_acronyms: config.go.uppercase_acronyms,
         }),
         #[cfg(not(feature = "go"))]
-        Some("go") => {
+        Some(SupportedLanguage::Go) => {
             panic!("go support is currently experimental and must be enabled as a feature flag for typeshare-cli")
         }
         _ => {

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -1,6 +1,6 @@
 use crate::rust_types::{RustTypeFormatError, SpecialRustType};
 use crate::{
-    language::Language,
+    language::{Language, SupportedLanguage},
     parser::remove_dash_from_identifier,
     rename::RenameExt,
     rust_types::{RustEnum, RustEnumVariant, RustStruct, RustTypeAlias},
@@ -210,10 +210,7 @@ impl Language for Swift {
         let mut decs = self.get_default_decorators();
 
         // Check if this struct's decorators contains swift in the hashmap
-        if rs.decorators.contains_key("swift") {
-            // this unwrap is safe since we just checked if we contain the key
-            let swift_decs = rs.decorators.get("swift").unwrap();
-
+        if let Some(swift_decs) = rs.decorators.get(&SupportedLanguage::Swift) {
             // For reach item in the received decorators in the typeshared struct add it to the original vector
             // this avoids duplicated of `Codable` without needing to `.sort()` then `.dedup()`
             // Note: the list received from `rs.decorators` is already deduped
@@ -331,7 +328,7 @@ impl Language for Swift {
                 .for_each(|dec| decs.push(dec));
 
             // Check if this enum's decorators contains swift in the hashmap
-            if let Some(swift_decs) = e.shared().decorators.get("swift") {
+            if let Some(swift_decs) = e.shared().decorators.get(&SupportedLanguage::Swift) {
                 // Add any decorators from the typeshared enum
                 decs.extend(
                     // Note: `swift_decs` is already deduped

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,6 +1,6 @@
 use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 use crate::{
-    language::Language,
+    language::{Language, SupportedLanguage},
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
 };
 use std::{collections::HashMap, io::Write};
@@ -222,7 +222,7 @@ impl TypeScript {
         let double_optional = field.ty.is_double_optional();
         let is_readonly = field
             .decorators
-            .get("typescript")
+            .get(&SupportedLanguage::TypeScript)
             .filter(|v| v.contains(&"readonly".to_string()))
             .is_some();
         writeln!(

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 use std::{collections::HashMap, convert::TryFrom};
 use thiserror::Error;
 
+use crate::language::SupportedLanguage;
+
 /// Identifier used in Rust structs, enums, and fields. It includes the `original` name and the `renamed` value after the transformation based on `serde` attributes.
 #[derive(Debug, Clone)]
 pub struct Id {
@@ -39,7 +41,7 @@ pub struct RustStruct {
     /// so we need to collect them here.
     pub comments: Vec<String>,
     /// Attributes that exist for this struct.
-    pub decorators: HashMap<String, Vec<String>>,
+    pub decorators: HashMap<SupportedLanguage, Vec<String>>,
 }
 
 /// Rust type alias.
@@ -72,8 +74,8 @@ pub struct RustField {
     /// for the languages we generate code for.
     pub has_default: bool,
     /// Language-specific decorators assigned to a given field.
-    /// The keys are language names (e.g. typescript), the values are decorators (e.g. readonly)
-    pub decorators: HashMap<String, HashSet<String>>,
+    /// The keys are language names (e.g. SupportedLanguage::TypeScript), the values are decorators (e.g. readonly)
+    pub decorators: HashMap<SupportedLanguage, HashSet<String>>,
 }
 
 /// A Rust type.
@@ -407,7 +409,7 @@ pub enum RustEnum {
     /// enum UnitEnum {
     ///     Variant,
     ///     AnotherVariant,
-    ///     Yay,    
+    ///     Yay,
     /// }
     /// ```
     Unit(RustEnumShared),
@@ -424,7 +426,7 @@ pub enum RustEnum {
     ///     AnonymousStruct {
     ///         field: String,
     ///         another_field: bool,
-    ///     },    
+    ///     },
     /// }
     /// ```
     Algebraic {
@@ -460,7 +462,7 @@ pub struct RustEnumShared {
     /// Decorators applied to the enum for generation in other languages
     ///
     /// Example: `#[typeshare(swift = "Equatable, Comparable, Hashable")]`.
-    pub decorators: HashMap<String, Vec<String>>,
+    pub decorators: HashMap<SupportedLanguage, Vec<String>>,
     /// True if this enum references itself in any field of any variant
     /// Swift needs the special keyword `indirect` for this case
     pub is_recursive: bool,


### PR DESCRIPTION
Potential fix for #68 

Instead of using `String` for the supported language names (e.g. `scala` or `kotlin`), we now represent the supported languages as ```enum SupportedLanguage```.  

Didn't change ALL of the `cli` crate code to use it, because at a minimum we would need to impl some clap traits or convert to &str in const context. Which means adding clap as a dependency to `core` or doing `impl const From<SupportedLanguage> for &str`, but const impl's are experimental. If there are other ways, I can implement it.