### PR TITLE
Add Scala support to CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,6 +9,7 @@ cargo install typeshare
 typeshare --lang=typescript some/file.rs
 typeshare --lang=swift some/file.rs
 typeshare --lang=kotlin --java-package=com.some.package.name some/file.rs
+typeshare --lang=scala --scala-package=com.some.package.name some/file.rs
 ```
 
 ## Generating FFI bindings

--- a/cli/data/tests/default_config.toml
+++ b/cli/data/tests/default_config.toml
@@ -5,6 +5,10 @@ prefix = ''
 module_name = ''
 package = ''
 
+[scala]
+module_name = ''
+package = ''
+
 [typescript]
 
 [go]
@@ -14,3 +18,5 @@ package = ''
 [typescript.type_mappings]
 
 [kotlin.type_mappings]
+
+[scala.type_mappings]

--- a/cli/data/tests/mappings_config.toml
+++ b/cli/data/tests/mappings_config.toml
@@ -7,5 +7,8 @@
 [kotlin.type_mappings]
 "DateTime" = "String"
 
+[scala.type_mappings]
+"DateTime" = "String"
+
 [go.type_mappings]
 "DateTime" = "string"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -144,6 +144,7 @@ mod test {
 
         assert_eq!(config.swift.type_mappings["DateTime"], "Date");
         assert_eq!(config.kotlin.type_mappings["DateTime"], "String");
+        assert_eq!(config.scala.type_mappings["DateTime"], "String");
         assert_eq!(config.typescript.type_mappings["DateTime"], "string");
         #[cfg(feature = "go")]
         assert_eq!(config.go.type_mappings["DateTime"], "string");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -88,7 +88,6 @@ fn build_command() -> Command<'static> {
         )
         .arg(
             Arg::new(ARG_SCALA_PACKAGE)
-                .short('S')
                 .long("scala-package")
                 .help("Scala package name")
                 .takes_value(true)
@@ -96,7 +95,6 @@ fn build_command() -> Command<'static> {
         )
         .arg(
             Arg::new(ARG_SCALA_MODULE_NAME)
-                .short('M')
                 .long("scala-module-name")
                 .help("Scala serializer module name")
                 .takes_value(true)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ use typeshare_core::{
     language::{Kotlin, Language, Swift, TypeScript},
     parser::ParsedData,
 };
+use typeshare_core::language::Scala;
 
 mod config;
 
@@ -23,6 +24,8 @@ const ARG_TYPE: &str = "TYPE";
 const ARG_SWIFT_PREFIX: &str = "SWIFTPREFIX";
 const ARG_JAVA_PACKAGE: &str = "JAVAPACKAGE";
 const ARG_MODULE_NAME: &str = "MODULENAME";
+const ARG_SCALA_PACKAGE: &str = "SCALAPACKAGE";
+const ARG_SCALA_MODULE_NAME: &str = "SCALAMODULENAME";
 #[cfg(feature = "go")]
 const ARG_GO_PACKAGE: &str = "GOPACKAGE";
 const ARG_CONFIG_FILE_NAME: &str = "CONFIGFILENAME";
@@ -30,10 +33,10 @@ const ARG_GENERATE_CONFIG: &str = "generate-config-file";
 const ARG_OUTPUT_FILE: &str = "output-file";
 
 #[cfg(feature = "go")]
-const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "swift", "typescript", "go"];
+const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
 
 #[cfg(not(feature = "go"))]
-const AVAILABLE_LANGUAGES: [&str; 3] = ["kotlin", "swift", "typescript"];
+const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];
 
 fn build_command() -> Command<'static> {
     command!("typeshare")
@@ -81,6 +84,22 @@ fn build_command() -> Command<'static> {
                 .short('m')
                 .long("module-name")
                 .help("Kotlin serializer module name")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::new(ARG_SCALA_PACKAGE)
+                .short('S')
+                .long("scala-package")
+                .help("Scala package name")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::new(ARG_SCALA_MODULE_NAME)
+                .short('M')
+                .long("scala-module-name")
+                .help("Scala serializer module name")
                 .takes_value(true)
                 .required(false),
         )
@@ -171,6 +190,11 @@ fn main() {
             package: config.kotlin.package,
             module_name: config.kotlin.module_name,
             type_mappings: config.kotlin.type_mappings,
+        }),
+        Some("scala") => Box::new(Scala {
+            package: config.scala.package,
+            module_name: config.scala.module_name,
+            type_mappings: config.scala.type_mappings,
         }),
         Some("typescript") => Box::new(TypeScript {
             type_mappings: config.typescript.type_mappings,
@@ -276,6 +300,14 @@ fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
 
     if let Some(module_name) = options.value_of(ARG_MODULE_NAME) {
         config.kotlin.module_name = module_name.to_string();
+    }
+
+    if let Some(scala_package) = options.value_of(ARG_SCALA_PACKAGE) {
+        config.scala.package = scala_package.to_string();
+    }
+
+    if let Some(scala_module_name) = options.value_of(ARG_SCALA_MODULE_NAME) {
+        config.scala.module_name = scala_module_name.to_string();
     }
 
     #[cfg(feature = "go")]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,10 +11,9 @@ use std::{fs, path::Path};
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
-    language::{Kotlin, Language, Swift, TypeScript},
+    language::{Kotlin, Language, Scala, Swift, TypeScript},
     parser::ParsedData,
 };
-use typeshare_core::language::Scala;
 
 mod config;
 

--- a/docs/src/usage/usage.md
+++ b/docs/src/usage/usage.md
@@ -9,6 +9,7 @@ To generate ffi definitions for a specific target language, run the `typeshare` 
 typeshare ./my_rust_project --lang=kotlin --output-file=my_kotlin_definitions.kt
 typeshare ./my_rust_project --lang=swift --output-file=my_swift_definitions.swift
 typeshare ./my_rust_project --lang=typescript --output-file=my_typescript_definitions.ts
+typeshare ./my_rust_project --lang=sca;a --output-file=my_scala_definitions.scala
 ```
 The first command-line argument is the name of the directory to search for Rust type definitions. The CLI will search all files in the specified directory tree for annotated Rust types. In addition to the input directory, you will also need to specify your desired target language and the output file to which the generated types will be written. This is done with the `--lang` and `--output-file` options respectively.
 
@@ -17,6 +18,7 @@ The currently supported output languages are:
 - Kotlin
 - Typescript
 - Swift
+- Scala
 - Go
 
 ---

--- a/docs/src/usage/usage.md
+++ b/docs/src/usage/usage.md
@@ -9,7 +9,7 @@ To generate ffi definitions for a specific target language, run the `typeshare` 
 typeshare ./my_rust_project --lang=kotlin --output-file=my_kotlin_definitions.kt
 typeshare ./my_rust_project --lang=swift --output-file=my_swift_definitions.swift
 typeshare ./my_rust_project --lang=typescript --output-file=my_typescript_definitions.ts
-typeshare ./my_rust_project --lang=sca;a --output-file=my_scala_definitions.scala
+typeshare ./my_rust_project --lang=scala --output-file=my_scala_definitions.scala
 ```
 The first command-line argument is the name of the directory to search for Rust type definitions. The CLI will search all files in the specified directory tree for annotated Rust types. In addition to the input directory, you will also need to specify your desired target language and the output file to which the generated types will be written. This is done with the `--lang` and `--output-file` options respectively.
 


### PR DESCRIPTION
# Motivation
When reading the docs for `typeshare`, I noticed that Scala was mentioned in the supported languages but it wasn't mentioned in the docs for the cli. 

Dug into the source code a bit and could see Scala was missing from `cli/src/main.rs`.

I figure there are two main possibilities:

1. Support for Scala isn't actually complete so you don't want to include it in the cli yet
2. After implementing Scala in the core crate, you forgot to add it to the cli crate. You guys are busy, after all. 

If it's the first option, then it's not a big issue because writing this PR didn't take very long anyway and you can just close it. 

If it _is_ the second option and this PR helps, then I'd propose a refactor/rewrite of the CLI (although I think it needs one anyway). In its current state I'd expect it's tricky to keep track of. 

I'd go for a more `struct`ured approach (😏), if you look at the sorts of features `clap` has integrated from [`structopt`](https://docs.rs/structopt/latest/structopt/) you'll see what I mean. Happy to open up a RFC issue with a more detailed proposal if you're interested, but I'm also happy to just crack on with it next weekend without an RFC if that's alright with you guys. I'd also look into adding some proper tests for the actual CLI functionality. 

# Changes
5734f27e6defc3f866a35413b75536a5fe810206: Added `"scala"` as a supported value for the `--lang` arg, along with args and overrides for `config.scala.package` and `config.scala.module_name`

5a7de2f93830b00ae8772ab967ee2b91e77faaaf: Added Scala values to the test configs

04c1a478fffc36d0d247ab693c56349cee62680c: Added mentions of Scala in the cli README and also in the book. Quite possible I've missed out some places where it should be mentioned though. 