### PR TITLE
Configurable Generic Constraints for Swift

### DIFF
--- a/cli/data/tests/constraints_config.toml
+++ b/cli/data/tests/constraints_config.toml
@@ -1,0 +1,2 @@
+[swift]
+default_generic_constraints = ["Sendable"]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -31,17 +31,17 @@ pub struct SwiftParams {
     pub prefix: String,
     pub type_mappings: HashMap<String, String>,
     pub default_decorators: Vec<String>,
-    pub default_generic_decorators: Vec<String>,
+    pub default_generic_constraints: Vec<String>,
 }
 
 impl Default for SwiftParams {
     fn default() -> Self {
-        let default_generic_decorators = vec!["Codable".into()];
+        let default_generic_constraints = vec!["Codable".into()];
         Self {
             prefix: Default::default(),
             type_mappings: Default::default(),
             default_decorators: Default::default(),
-            default_generic_decorators,
+            default_generic_constraints,
         }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -25,12 +25,25 @@ pub struct ScalaParams {
     pub type_mappings: HashMap<String, String>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(default)]
 pub struct SwiftParams {
     pub prefix: String,
     pub type_mappings: HashMap<String, String>,
     pub default_decorators: Vec<String>,
+    pub default_generic_decorators: Vec<String>,
+}
+
+impl Default for SwiftParams {
+    fn default() -> Self {
+        let default_generic_decorators = vec!["Codable".into()];
+        Self {
+            prefix: Default::default(),
+            type_mappings: Default::default(),
+            default_decorators: Default::default(),
+            default_generic_decorators,
+        }
+    }
 }
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -25,25 +25,13 @@ pub struct ScalaParams {
     pub type_mappings: HashMap<String, String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(default)]
 pub struct SwiftParams {
     pub prefix: String,
     pub type_mappings: HashMap<String, String>,
     pub default_decorators: Vec<String>,
     pub default_generic_constraints: Vec<String>,
-}
-
-impl Default for SwiftParams {
-    fn default() -> Self {
-        let default_generic_constraints = vec!["Codable".into()];
-        Self {
-            prefix: Default::default(),
-            type_mappings: Default::default(),
-            default_decorators: Default::default(),
-            default_generic_constraints,
-        }
-    }
 }
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -173,6 +173,15 @@ mod test {
     }
 
     #[test]
+    fn constraints_test() {
+        let path = config_file_path("constraints_config.toml");
+        let config = load_config(Some(path)).unwrap();
+
+        assert_eq!(config.swift.default_generic_constraints.len(), 1);
+        assert_eq!(config.swift.default_generic_constraints[0], "Sendable");
+    }
+
+    #[test]
     fn swift_prefix_test() {
         let path = config_file_path("swift_prefix_config.toml");
         let config = load_config(Some(path)).unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{fs, path::Path};
+use typeshare_core::language::GenericDecorators;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
@@ -184,6 +185,9 @@ fn main() {
             prefix: config.swift.prefix,
             type_mappings: config.swift.type_mappings,
             default_decorators: config.swift.default_decorators,
+            default_generic_decorators: GenericDecorators::from_config(
+                config.swift.default_generic_decorators,
+            ),
             ..Default::default()
         }),
         Some(SupportedLanguage::Kotlin) => Box::new(Kotlin {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{fs, path::Path};
-use typeshare_core::language::GenericDecorators;
+use typeshare_core::language::GenericConstraints;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
@@ -185,8 +185,8 @@ fn main() {
             prefix: config.swift.prefix,
             type_mappings: config.swift.type_mappings,
             default_decorators: config.swift.default_decorators,
-            default_generic_decorators: GenericDecorators::from_config(
-                config.swift.default_generic_decorators,
+            default_generic_constraints: GenericConstraints::from_config(
+                config.swift.default_generic_constraints,
             ),
             ..Default::default()
         }),

--- a/core/data/tests/generates_configured_generic_constraints/output.swift
+++ b/core/data/tests/generates_configured_generic_constraints/output.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/core/data/tests/test_default_generic_constraints/input.rs
+++ b/core/data/tests/test_default_generic_constraints/input.rs
@@ -1,0 +1,4 @@
+#[typeshare]
+struct GenericType<T> {
+    field: T
+}

--- a/core/data/tests/test_default_generic_constraints/output.swift
+++ b/core/data/tests/test_default_generic_constraints/output.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct GenericType<T: Codable & Identifiable & Sendable>: Codable {
+	public let field: T
+
+	public init(field: T) {
+		self.field = field
+	}
+}

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -17,7 +17,7 @@ use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 pub use go::Go;
 pub use kotlin::Kotlin;
 pub use scala::Scala;
-pub use swift::GenericDecorators;
+pub use swift::GenericConstraints;
 pub use swift::Swift;
 pub use typescript::TypeScript;
 

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -17,6 +17,7 @@ use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 pub use go::Go;
 pub use kotlin::Kotlin;
 pub use scala::Scala;
+pub use swift::GenericDecorators;
 pub use swift::Swift;
 pub use typescript::TypeScript;
 

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -75,8 +75,6 @@ const SWIFT_KEYWORDS: &[&str] = &[
 
 const CODABLE: &str = "Codable";
 
-const GENERIC_DECORATORS: &str = "generic_decorators";
-
 /// Information on serialization/deserialization coding keys.
 /// TODO: expand on this.
 #[derive(Debug)]
@@ -248,7 +246,7 @@ impl Language for Swift {
         // If there are no decorators found for this struct, still write `Codable` and default decorators for structs
         let mut decs = self.get_default_decorators();
 
-        let mut default_generic_decorators = self.default_generic_decorators.clone();
+        let default_generic_decorators = self.default_generic_decorators.clone();
         // Check if this struct's decorators contains swift in the hashmap
         if let Some(swift_decs) = rs.decorators.get(&SupportedLanguage::Swift) {
             // For reach item in the received decorators in the typeshared struct add it to the original vector
@@ -258,10 +256,6 @@ impl Language for Swift {
                 .iter()
                 .filter(|d| d.as_str() != CODABLE)
                 .for_each(|d| decs.push(d.clone()));
-            swift_decs
-                .iter()
-                .filter(|d| d.as_str() == GENERIC_DECORATORS)
-                .for_each(|d| default_generic_decorators.add(d.clone()))
         }
 
         let generic_dec_string = default_generic_decorators.get_decorators().join(" & ");

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -96,7 +96,7 @@ impl GenericDecorators {
         Self {
             decorators: decorators
                 .into_iter()
-                .flat_map(|d| Self::split_decorators(d))
+                .flat_map(Self::split_decorators)
                 .collect(),
         }
     }

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -85,20 +85,19 @@ struct CodingKeysInfo {
 }
 
 /// A container for generic constraints.
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct GenericConstraints {
-    decorators: HashSet<String>,
+    constraints: HashSet<String>,
 }
 
 impl GenericConstraints {
     /// Create a container for generic constraints from a list of strings.
     /// Each string will be broken up by `&`, the syntax that Swift uses to combine constraints,
     /// and the complete list will be de-duplicated.
-    pub fn from_config(decorators: Vec<String>) -> Self {
+    pub fn from_config(constraints: Vec<String>) -> Self {
         Self {
-            decorators: decorators
-                .into_iter()
-                .flat_map(Self::split_constraints)
+            constraints: std::iter::once(CODABLE.into())
+                .chain(constraints.into_iter().flat_map(Self::split_constraints))
                 .collect(),
         }
     }
@@ -106,12 +105,12 @@ impl GenericConstraints {
     /// This expression will be broken up by `&`, the syntax that Swift uses to combine constraints.
     pub fn add(&mut self, constraints: String) {
         for decorator in Self::split_constraints(constraints).into_iter() {
-            self.decorators.insert(decorator);
+            self.constraints.insert(decorator);
         }
     }
     /// Get an iterator over all constraints.
     pub fn get_constraints(&self) -> impl Iterator<Item = &String> {
-        self.decorators.iter()
+        self.constraints.iter()
     }
 
     fn split_constraints(constraints: String) -> Vec<String> {
@@ -119,6 +118,12 @@ impl GenericConstraints {
             .split('&')
             .map(|s| s.trim().to_owned())
             .collect()
+    }
+}
+
+impl Default for GenericConstraints {
+    fn default() -> Self {
+        Self::from_config(vec![])
     }
 }
 

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -8,7 +8,7 @@ use crate::{
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::{
     collections::HashMap,
     io::Write,
@@ -87,7 +87,7 @@ struct CodingKeysInfo {
 /// A container for generic constraints.
 #[derive(Debug, Clone)]
 pub struct GenericConstraints {
-    constraints: HashSet<String>,
+    constraints: BTreeSet<String>,
 }
 
 impl GenericConstraints {

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -178,7 +178,6 @@ macro_rules! language_instance {
         #[allow(clippy::needless_update)]
         Box::new(typeshare_core::language::Swift {
             no_version_header: true,
-            default_generic_constraints: typeshare_core::language::GenericDecorators::from_config(vec!["Codable".into()]),
             $($field: $val,)*
             ..Default::default()
         })
@@ -455,6 +454,7 @@ tests! {
     // TODO: kotlin and typescript don't appear to support this yet
     generates_empty_structs_and_initializers: [swift, kotlin, scala, typescript, go];
     test_default_decorators: [swift { default_decorators: vec!["Sendable".into(), "Identifiable".into()]}];
+    test_default_generic_constraints: [swift { default_generic_constraints: typeshare_core::language::GenericConstraints::from_config(vec!["Sendable".into(), "Identifiable".into()]) }];
     test_i54_u53_type: [swift, kotlin, scala,  typescript, go];
     test_serde_default_struct: [swift, kotlin, scala,  typescript, go];
     test_serde_iso8601: [

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -178,7 +178,7 @@ macro_rules! language_instance {
         #[allow(clippy::needless_update)]
         Box::new(typeshare_core::language::Swift {
             no_version_header: true,
-            default_generic_decorators: typeshare_core::language::GenericDecorators::from_config(vec!["Codable".into()]),
+            default_generic_constraints: typeshare_core::language::GenericDecorators::from_config(vec!["Codable".into()]),
             $($field: $val,)*
             ..Default::default()
         })

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -178,6 +178,7 @@ macro_rules! language_instance {
         #[allow(clippy::needless_update)]
         Box::new(typeshare_core::language::Swift {
             no_version_header: true,
+            default_generic_decorators: typeshare_core::language::GenericDecorators::from_config(vec!["Codable".into()]),
             $($field: $val,)*
             ..Default::default()
         })


### PR DESCRIPTION
Resolves #86.

Default type constraints can now be specified for Swift within the config, using `default_generic_constraints = [...]` under `[swift]`. Constraint strings within the list can include multiple constraints, such as `Sendable & Identifiable`.