### PR TITLE
Set up a nix flake for typeshare

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681303793,
+        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+# Nix Flake for installing typeshare outside of the NixPkgs source tree.
+#
+# Thank you to figsoda, who originally wrote the package build and install
+# instructions. I (savannidgerinel) copied that stanza from the nixpkgs
+# repository.
+# https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/tools/rust/typeshare/default.nix#L32
+#
+# To use this in your repository, 
+{
+  description = "Create types in Rust and convert them to other languages";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils }:
+  flake-utils.lib.eachSystem ["x86_64-linux"] (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+        typeshare = with pkgs;
+          rustPlatform.buildRustPackage rec {
+          pname = "typeshare";
+          version = (builtins.fromTOML (builtins.readFile ./cli/Cargo.toml)).package.version;
+
+          src = lib.cleanSource ./.;
+
+          cargoLock = { lockFile = ./Cargo.lock; };
+
+          nativeBuildInputs = [ installShellFiles ];
+
+          buildFeatures = [ "go" ];
+
+          postInstall = ''
+            installShellCompletion --cmd typeshare \
+              --bash <($out/bin/typeshare completions bash) \
+              --fish <($out/bin/typeshare completions fish) \
+              --zsh <($out/bin/typeshare completions zsh)
+          '';
+
+          meta = with lib; {
+            description = "Command Line Tool for generating language files with typeshare";
+            homepage = "https://github.com/1password/typeshare";
+            changelog = "https://github.com/1password/typeshare/blob/v${version}/CHANGELOG.md";
+            license = with licenses; [ asl20 /* or */ mit ];
+          };
+        };
+    in rec {
+      packages.default = typeshare;
+    });
+}


### PR DESCRIPTION
This allows Nix users to include Typeshare in their projects directly, or even to run typeshare on the command line. Nix users will be able to pin against past releases of the package by setting a version number or even a particular commit in their `flake.nix` file when importing the Typeshare flake.