### PR TITLE
Typeshare can now detect types within embedded modules

### DIFF
--- a/core/data/tests/can_recognize_types_inside_modules/input.rs
+++ b/core/data/tests/can_recognize_types_inside_modules/input.rs
@@ -1,0 +1,23 @@
+mod a {
+    #[typeshare]
+    pub struct A {
+        field: u32
+    }
+    mod b {
+        mod c {
+            #[typeshare]
+            pub struct ABC {
+                field: u32
+            }
+        }
+        #[typeshare]
+        pub struct AB {
+            field: u32
+        }
+    }
+}
+
+#[typeshare]
+pub struct OutsideOfModules {
+    field: u32
+}

--- a/core/data/tests/can_recognize_types_inside_modules/output.go
+++ b/core/data/tests/can_recognize_types_inside_modules/output.go
@@ -1,0 +1,16 @@
+package proto
+
+import "encoding/json"
+
+type A struct {
+	Field uint32 `json:"field"`
+}
+type ABC struct {
+	Field uint32 `json:"field"`
+}
+type AB struct {
+	Field uint32 `json:"field"`
+}
+type OutsideOfModules struct {
+	Field uint32 `json:"field"`
+}

--- a/core/data/tests/can_recognize_types_inside_modules/output.kt
+++ b/core/data/tests/can_recognize_types_inside_modules/output.kt
@@ -1,0 +1,27 @@
+@file:NoLiveLiterals
+
+package com.agilebits.onepassword
+
+import androidx.compose.runtime.NoLiveLiterals
+import kotlinx.serialization.*
+
+@Serializable
+data class A (
+	val field: UInt
+)
+
+@Serializable
+data class ABC (
+	val field: UInt
+)
+
+@Serializable
+data class AB (
+	val field: UInt
+)
+
+@Serializable
+data class OutsideOfModules (
+	val field: UInt
+)
+

--- a/core/data/tests/can_recognize_types_inside_modules/output.scala
+++ b/core/data/tests/can_recognize_types_inside_modules/output.scala
@@ -1,0 +1,29 @@
+package com.agilebits
+
+package object onepassword {
+
+type UByte = Byte
+type UShort = Short
+type UInt = Int
+type ULong = Int
+
+}
+package onepassword {
+
+case class A (
+	field: UInt
+)
+
+case class ABC (
+	field: UInt
+)
+
+case class AB (
+	field: UInt
+)
+
+case class OutsideOfModules (
+	field: UInt
+)
+
+}

--- a/core/data/tests/can_recognize_types_inside_modules/output.swift
+++ b/core/data/tests/can_recognize_types_inside_modules/output.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct A: Codable {
+	public let field: UInt32
+
+	public init(field: UInt32) {
+		self.field = field
+	}
+}
+
+public struct ABC: Codable {
+	public let field: UInt32
+
+	public init(field: UInt32) {
+		self.field = field
+	}
+}
+
+public struct AB: Codable {
+	public let field: UInt32
+
+	public init(field: UInt32) {
+		self.field = field
+	}
+}
+
+public struct OutsideOfModules: Codable {
+	public let field: UInt32
+
+	public init(field: UInt32) {
+		self.field = field
+	}
+}

--- a/core/data/tests/can_recognize_types_inside_modules/output.ts
+++ b/core/data/tests/can_recognize_types_inside_modules/output.ts
@@ -1,0 +1,16 @@
+export interface A {
+	field: number;
+}
+
+export interface ABC {
+	field: number;
+}
+
+export interface AB {
+	field: number;
+}
+
+export interface OutsideOfModules {
+	field: number;
+}
+

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -110,7 +110,7 @@ pub fn parse(input: &str) -> Result<ParsedData, ParseError> {
 fn flatten_items<'a>(items: impl Iterator<Item=&'a syn::Item>) -> impl Iterator<Item=&'a syn::Item> {
     items.flat_map(|item| match item {
         syn::Item::Mod(syn::ItemMod { content: Some((_, items)), .. }) => {
-            items.iter().collect()
+            flatten_items(items.iter()).collect()
         },
         item => vec![item]
     }.into_iter())

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -107,6 +107,8 @@ pub fn parse(input: &str) -> Result<ParsedData, ParseError> {
     Ok(parsed_data)
 }
 
+/// Given an iterator over items, will return an iterator that flattens the contents of embedded
+/// module items into the iterator.
 fn flatten_items<'a>(items: impl Iterator<Item=&'a syn::Item>) -> impl Iterator<Item=&'a syn::Item> {
     items.flat_map(|item| match item {
         syn::Item::Mod(syn::ItemMod { content: Some((_, items)), .. }) => {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -109,13 +109,19 @@ pub fn parse(input: &str) -> Result<ParsedData, ParseError> {
 
 /// Given an iterator over items, will return an iterator that flattens the contents of embedded
 /// module items into the iterator.
-fn flatten_items<'a>(items: impl Iterator<Item=&'a syn::Item>) -> impl Iterator<Item=&'a syn::Item> {
-    items.flat_map(|item| match item {
-        syn::Item::Mod(syn::ItemMod { content: Some((_, items)), .. }) => {
-            flatten_items(items.iter()).collect()
-        },
-        item => vec![item]
-    }.into_iter())
+fn flatten_items<'a>(
+    items: impl Iterator<Item = &'a syn::Item>,
+) -> impl Iterator<Item = &'a syn::Item> {
+    items.flat_map(|item| {
+        match item {
+            syn::Item::Mod(syn::ItemMod {
+                content: Some((_, items)),
+                ..
+            }) => flatten_items(items.iter()).collect(),
+            item => vec![item],
+        }
+        .into_iter()
+    })
 }
 
 /// Parses a struct into a definition that more succinctly represents what

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -406,6 +406,9 @@ tests! {
     can_generate_double_option_pattern: [
         typescript
     ];
+    can_recognize_types_inside_modules: [
+        swift, kotlin, scala, typescript, go
+    ];
     test_simple_enum_case_name_support: [swift, kotlin, scala, typescript, go ];
     test_algebraic_enum_case_name_support: [
         swift {


### PR DESCRIPTION
Say, for instance, you have this situation:

```
mod inline_module {
  #[typeshare]
  pub struct Inline;
}
```

Previously, `Inline` would not be detected since our parser was not scanning the contents of inline/embedded modules. This has been fixed.

Resolves #40 