### PR TITLE
Adds more useful output for invalid UTF8 encoding error.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,7 +261,7 @@ fn main() {
     let parsed_data = glob_paths
         .par_iter()
         .map(|filepath| {
-            let data = std::fs::read_to_string(filepath).unwrap();
+            let data = std::fs::read_to_string(filepath).map_err(|e| panic!("{filepath}, {e}")).unwrap();
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());


### PR DESCRIPTION
When using `typeshare-cli` I got an error about invalid UTF-8 encoding of a file:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: InvalidData, message: "stream did not contain valid UTF-8" }', cli/src/main.rs:264:58
```
While the error was helpful about 'what' the error was, I had to backtrack which file was affected.
This PR implements a more verbose error message by also listing the affected file, see:

```
thread '<unnamed>' panicked at '/testproject/core/._nonUT8file.rs, stream did not contain valid UTF-8', cli/src/main.rs:264:70
```