### PR TITLE
Adds more useful output for invalid UTF8 error.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,7 +261,9 @@ fn main() {
     let parsed_data = glob_paths
         .par_iter()
         .map(|filepath| {
-            let data = std::fs::read_to_string(filepath).map_err(|e| format!("{filepath}, {e}")).unwrap();
+            let data = std::fs::read_to_string(filepath)
+                .map_err(|e| format!("{filepath}, {e}"))
+                .unwrap();
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,7 +261,7 @@ fn main() {
     let parsed_data = glob_paths
         .par_iter()
         .map(|filepath| {
-            let data = std::fs::read_to_string(filepath).unwrap();
+            let data = std::fs::read_to_string(filepath).map_err(|e| panic!("{filepath}, {e}")).unwrap();
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -262,8 +262,7 @@ fn main() {
         .par_iter()
         .map(|filepath| {
             let data = std::fs::read_to_string(filepath)
-                .map_err(|e| format!("{filepath}, {e}"))
-                .unwrap();
+                .unwrap_or_else(|e| panic!("failed to read file at {filepath:?}: {e}"));
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,7 +261,7 @@ fn main() {
     let parsed_data = glob_paths
         .par_iter()
         .map(|filepath| {
-            let data = std::fs::read_to_string(filepath).map_err(|e| panic!("{filepath}, {e}")).unwrap();
+            let data = std::fs::read_to_string(filepath).map_err(|e| format!("{filepath}, {e}")).unwrap();
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());


### PR DESCRIPTION
When using the `typheshare-cli` I got an error notifying me of a file that has invalid UTF8 encoding:
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: InvalidData, message: "stream did not contain valid UTF-8" }', cli/src/main.rs:264:58
```

I still had to manually backtrace which file was affected, so I implemented a more useful error message for this case that additionally lists the file path:

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: "/project/core/._nonUTF8file.rs, stream did not contain valid UTF-8"', cli/src/main.rs:264:98
```