### PR TITLE
Field decorator parsing rework

### DIFF
--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -33,6 +33,7 @@ pub enum SupportedLanguage {
 }
 
 impl SupportedLanguage {
+    /// Returns an iterator over all supported language variants.
     pub fn all_languages() -> impl Iterator<Item = Self> {
         use SupportedLanguage::*;
         [Go, Kotlin, Scala, Swift, TypeScript].into_iter()

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -32,6 +32,13 @@ pub enum SupportedLanguage {
     TypeScript,
 }
 
+impl SupportedLanguage {
+    pub fn all_languages() -> impl Iterator<Item = Self> {
+        use SupportedLanguage::*;
+        [Go, Kotlin, Scala, Swift, TypeScript].into_iter()
+    }
+}
+
 impl FromStr for SupportedLanguage {
     type Err = ParseError;
 

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,6 +1,6 @@
 use joinery::JoinableIterator;
 
-use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{FieldDecorator, RustType, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::{Language, SupportedLanguage},
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
@@ -239,7 +239,7 @@ impl TypeScript {
         let is_readonly = field
             .decorators
             .get(&SupportedLanguage::TypeScript)
-            .filter(|v| v.contains(&"readonly".to_string()))
+            .filter(|v| v.contains(&FieldDecorator::Word("readonly".to_string())))
             .is_some();
         writeln!(
             w,

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,6 +1,6 @@
 use joinery::JoinableIterator;
 
-use crate::rust_types::{FieldDecorator, RustType, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::{Language, SupportedLanguage},
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
@@ -239,7 +239,7 @@ impl TypeScript {
         let is_readonly = field
             .decorators
             .get(&SupportedLanguage::TypeScript)
-            .filter(|v| v.contains(&FieldDecorator::Word("readonly".to_string())))
+            .filter(|v| v.iter().any(|dec| dec.name() == "readonly"))
             .is_some();
         writeln!(
             w,

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -588,22 +588,20 @@ fn get_field_decorators(
         .map(|(language, list)| {
             (
                 language,
-                list.into_iter()
-                    .filter_map(|nested| match nested {
-                        NestedMeta::Meta(Meta::Path(path)) if path.segments.len() == 1 => {
-                            Some(FieldDecorator::Word(path.get_ident()?.to_string()))
-                        }
-                        NestedMeta::Meta(Meta::NameValue(name_value)) => {
-                            Some(FieldDecorator::NameValue(
-                                name_value.path.get_ident()?.to_string(),
-                                literal_as_string(name_value.lit)?,
-                            ))
-                        }
-                        // TODO: this should throw a visible error since it suggests a malformed
-                        //       attribute.
-                        _ => None,
-                    })
-                    .collect::<BTreeSet<_>>(),
+                list.into_iter().filter_map(|nested| match nested {
+                    NestedMeta::Meta(Meta::Path(path)) if path.segments.len() == 1 => {
+                        Some(FieldDecorator::Word(path.get_ident()?.to_string()))
+                    }
+                    NestedMeta::Meta(Meta::NameValue(name_value)) => {
+                        Some(FieldDecorator::NameValue(
+                            name_value.path.get_ident()?.to_string(),
+                            literal_as_string(name_value.lit)?,
+                        ))
+                    }
+                    // TODO: this should throw a visible error since it suggests a malformed
+                    //       attribute.
+                    _ => None,
+                }),
             )
         })
         .fold(HashMap::new(), |mut acc, (language, decorators)| {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -588,17 +588,19 @@ fn get_field_decorators(
         .map(|(language, list)| {
             (
                 language,
-                list.iter()
-                    .flat_map(|nested| match nested {
-                        NestedMeta::Meta(Meta::Path(path)) => {
+                list.into_iter()
+                    .filter_map(|nested| match nested {
+                        NestedMeta::Meta(Meta::Path(path)) if path.segments.len() == 1 => {
                             Some(FieldDecorator::Word(path.get_ident()?.to_string()))
                         }
                         NestedMeta::Meta(Meta::NameValue(name_value)) => {
                             Some(FieldDecorator::NameValue(
                                 name_value.path.get_ident()?.to_string(),
-                                literal_as_string(name_value.lit.clone())?,
+                                literal_as_string(name_value.lit)?,
                             ))
                         }
+                        // TODO: this should throw a visible error since it suggests a malformed
+                        //       attribute.
                         _ => None,
                     })
                     .collect::<BTreeSet<_>>(),

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -89,9 +89,10 @@ pub enum FieldDecorator {
 }
 
 impl FieldDecorator {
+    /// Returns the name of the field decorator. For a word decorator, this is just the identifier.
     pub fn name(&self) -> &str {
         match self {
-            Self::Word(name) | Self::NameValue(name, _) => &name,
+            Self::Word(name) | Self::NameValue(name, _) => name,
         }
     }
 }

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -88,6 +88,14 @@ pub enum FieldDecorator {
     NameValue(String, String),
 }
 
+impl FieldDecorator {
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Word(name) | Self::NameValue(name, _) => &name,
+        }
+    }
+}
+
 /// A Rust type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RustType {

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -1,5 +1,5 @@
 use quote::ToTokens;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::str::FromStr;
 use std::{collections::HashMap, convert::TryFrom};
 use syn::{Expr, ExprLit, Lit, TypeArray};
@@ -75,8 +75,17 @@ pub struct RustField {
     /// for the languages we generate code for.
     pub has_default: bool,
     /// Language-specific decorators assigned to a given field.
-    /// The keys are language names (e.g. SupportedLanguage::TypeScript), the values are decorators (e.g. readonly)
-    pub decorators: HashMap<SupportedLanguage, HashSet<String>>,
+    /// The keys are language names (e.g. SupportedLanguage::TypeScript), the values are field decorators (e.g. readonly)
+    pub decorators: HashMap<SupportedLanguage, BTreeSet<FieldDecorator>>,
+}
+
+/// A single decorator on a field in Rust code.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FieldDecorator {
+    /// A boolean flag enabled by its existence as a decorator: for example, `readonly`.
+    Word(String),
+    /// A key-value pair, such as `type = "any"`.
+    NameValue(String, String),
 }
 
 /// A Rust type.


### PR DESCRIPTION
Needed for #22.

Parsing for `typeshare(<lang>(<decorator>))` only supports word decorators like `readonly` currently. This PR reworks how we parse field decorators to support name-value decorators too, like `typeshare(swift(type = "String"))`.