### PR TITLE
Apply generic constraints to enums

### DIFF
--- a/core/data/tests/test_default_generic_constraints/input.rs
+++ b/core/data/tests/test_default_generic_constraints/input.rs
@@ -1,4 +1,14 @@
 #[typeshare]
-struct GenericType<T> {
-    field: T
+struct GenericType<K, V> {
+    key: K,
+    value: V
+}
+
+#[typeshare]
+#[serde(tag = "type", content = "content")]
+enum GenericEnum<K, V> {
+    Variant {
+        key: K,
+        value: V
+    }
 }

--- a/core/data/tests/test_default_generic_constraints/output.swift
+++ b/core/data/tests/test_default_generic_constraints/output.swift
@@ -1,9 +1,57 @@
 import Foundation
 
-public struct GenericType<T: Codable & Identifiable & Sendable>: Codable {
-	public let field: T
+public struct GenericType<K: Codable & Identifiable & Sendable, V: Codable & Identifiable & Sendable>: Codable {
+	public let key: K
+	public let value: V
 
-	public init(field: T) {
-		self.field = field
+	public init(key: K, value: V) {
+		self.key = key
+		self.value = value
+	}
+}
+
+
+/// Generated type representing the anonymous struct variant `Variant` of the `GenericEnum` Rust enum
+public struct GenericEnumVariantInner<K: Codable & Identifiable & Sendable, V: Codable & Identifiable & Sendable>: Codable {
+	public let key: K
+	public let value: V
+
+	public init(key: K, value: V) {
+		self.key = key
+		self.value = value
+	}
+}
+public enum GenericEnum<K: Codable & Identifiable & Sendable, V: Codable & Identifiable & Sendable>: Codable {
+	case variant(GenericEnumVariantInner<K, V>)
+
+	enum CodingKeys: String, CodingKey, Codable {
+		case variant = "Variant"
+	}
+
+	private enum ContainerCodingKeys: String, CodingKey {
+		case type, content
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
+		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
+			switch type {
+			case .variant:
+				if let content = try? container.decode(GenericEnumVariantInner<K, V>.self, forKey: .content) {
+					self = .variant(content)
+					return
+				}
+			}
+		}
+		throw DecodingError.typeMismatch(GenericEnum.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for GenericEnum"))
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
+		switch self {
+		case .variant(let content):
+			try container.encode(CodingKeys.variant, forKey: .type)
+			try container.encode(content, forKey: .content)
+		}
 	}
 }

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -440,6 +440,17 @@ impl Language for Swift {
         // Generate named types for any anonymous struct variants of this enum
         self.write_types_for_anonymous_structs(w, e, &make_anonymous_struct_name)?;
 
+        let codable = CODABLE.to_string();
+        let mut default_generic_constraints = self
+            .default_generic_constraints
+            .constraints
+            .iter()
+            .map(|s| s.clone())
+            .collect::<Vec<_>>();
+        if !default_generic_constraints.contains(&codable) {
+            default_generic_constraints.push(codable);
+        }
+
         self.write_comments(w, 0, &shared.comments)?;
         let indirect = if shared.is_recursive { "indirect " } else { "" };
         writeln!(
@@ -449,8 +460,9 @@ impl Language for Swift {
             enum_name,
             (!e.shared().generic_types.is_empty())
                 .then(|| format!(
-                    "<{}: Codable>",
-                    e.shared().generic_types.join(": Codable, ")
+                    "<{}: {}>",
+                    e.shared().generic_types.join(": Codable, "),
+                    default_generic_constraints.join(" & ")
                 ))
                 .unwrap_or_default(),
             decs.join(", ")


### PR DESCRIPTION
This MR applies default generic constraints to Swift enums with associated values in the same way that it does for structs.

Resolves #121 