### PR TITLE
Add typescript option to generate readonly types

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -38,6 +38,8 @@ pub struct SwiftParams {
 #[serde(default)]
 pub struct TypeScriptParams {
     pub type_mappings: HashMap<String, String>,
+    #[serde(default)]
+    pub readonly: bool,
 }
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -204,6 +204,7 @@ fn main() {
         }),
         Some(SupportedLanguage::TypeScript) => Box::new(TypeScript {
             type_mappings: config.typescript.type_mappings,
+            readonly: config.typescript.readonly,
             ..Default::default()
         }),
         #[cfg(feature = "go")]


### PR DESCRIPTION
It's common in typescript to avoid in-place mutations. This PR allows fully read-only types to be generated.

For object types, this could previously already be achieved via lots of annotations, but this is tedious and there was no way to apply the "readonly" modifier to maps and arrays.