### PR TITLE
Support tuple struct without fields

### DIFF
--- a/core/data/tests/can_handle_tuple_struct_without_fields/input.rs
+++ b/core/data/tests/can_handle_tuple_struct_without_fields/input.rs
@@ -1,0 +1,5 @@
+#[typeshare::typeshare]
+pub struct MyTypeA();
+
+#[typeshare::typeshare]
+pub struct MyTypeB(pub ());

--- a/core/data/tests/can_handle_tuple_struct_without_fields/output.go
+++ b/core/data/tests/can_handle_tuple_struct_without_fields/output.go
@@ -1,0 +1,8 @@
+package proto
+
+import "encoding/json"
+
+type MyTypeA struct{}
+
+type MyTypeB struct{}
+

--- a/core/data/tests/can_handle_tuple_struct_without_fields/output.kt
+++ b/core/data/tests/can_handle_tuple_struct_without_fields/output.kt
@@ -1,0 +1,11 @@
+@file:NoLiveLiterals
+
+package com.agilebits.onepassword
+
+import androidx.compose.runtime.NoLiveLiterals
+import kotlinx.serialization.*
+
+typealias MyTypeA = Unit
+
+typealias MyTypeB = Unit
+

--- a/core/data/tests/can_handle_tuple_struct_without_fields/output.swift
+++ b/core/data/tests/can_handle_tuple_struct_without_fields/output.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public typealias MyTypeA = CodableVoid
+
+public typealias MyTypeB = CodableVoid
+
+/// () isn't codable, so we use this instead to represent Rust's unit type
+public struct CodableVoid: Codable {}

--- a/core/data/tests/can_handle_tuple_struct_without_fields/output.ts
+++ b/core/data/tests/can_handle_tuple_struct_without_fields/output.ts
@@ -1,0 +1,4 @@
+export type MyTypeA = undefined;
+
+export type MyTypeB = undefined;
+

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::rust_types::FieldDecorator;
+use crate::rust_types::{FieldDecorator, SpecialRustType};
 use crate::{
     language::SupportedLanguage,
     rename::RenameExt,
@@ -202,6 +202,16 @@ fn parse_struct(s: &ItemStruct) -> Result<RustItem, ParseError> {
             if f.unnamed.len() > 1 {
                 return Err(ParseError::ComplexTupleStruct);
             }
+
+            if f.unnamed.is_empty() {
+                return Ok(RustItem::Alias(RustTypeAlias {
+                    id: get_ident(Some(&s.ident), &s.attrs, &None),
+                    r#type: RustType::Special(SpecialRustType::Unit),
+                    comments: parse_comment_attrs(&s.attrs),
+                    generic_types,
+                }));
+            }
+
             let f = &f.unnamed[0];
 
             let ty = if let Some(ty) = get_field_type_override(&f.attrs) {

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -430,7 +430,8 @@ tests! {
     can_generate_algebraic_enum_with_skipped_variants: [swift, kotlin, scala,  typescript, go];
     can_generate_struct_with_skipped_fields: [swift, kotlin, scala,  typescript, go];
     enum_is_properly_named_with_serde_overrides: [swift, kotlin, scala,  typescript, go];
-    can_handle_quote_in_serde_rename: [swift, kotlin, scala,  typescript, go];
+    can_handle_tuple_struct_without_fields: [swift, kotlin, typescript, go];
+    can_handle_quote_in_serde_rename: [swift, kotlin, scala, typescript, go];
     can_handle_anonymous_struct: [swift, kotlin, scala,  typescript, go];
     anonymous_struct_with_rename: [
         swift {


### PR DESCRIPTION
Handles tuple structs without any fields or visibility modifiers.

Closes #42 