### PR TITLE
Support char type

### DIFF
--- a/core/data/tests/test_generate_char/input.rs
+++ b/core/data/tests/test_generate_char/input.rs
@@ -1,0 +1,4 @@
+#[typeshare]
+struct MyType {
+    field: char,
+}

--- a/core/data/tests/test_generate_char/output.go
+++ b/core/data/tests/test_generate_char/output.go
@@ -1,0 +1,7 @@
+package proto
+
+import "encoding/json"
+
+type MyType struct {
+	Field rune `json:"field"`
+}

--- a/core/data/tests/test_generate_char/output.kt
+++ b/core/data/tests/test_generate_char/output.kt
@@ -1,0 +1,12 @@
+@file:NoLiveLiterals
+
+package com.agilebits.onepassword
+
+import androidx.compose.runtime.NoLiveLiterals
+import kotlinx.serialization.*
+
+@Serializable
+data class MyType (
+	val field: String
+)
+

--- a/core/data/tests/test_generate_char/output.scala
+++ b/core/data/tests/test_generate_char/output.scala
@@ -1,0 +1,9 @@
+package com.agilebits
+
+package onepassword {
+
+case class MyType (
+	field: String
+)
+
+}

--- a/core/data/tests/test_generate_char/output.swift
+++ b/core/data/tests/test_generate_char/output.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct MyType: Codable {
+	public let field: Unicode.Scalar
+
+	public init(field: Unicode.Scalar) {
+		self.field = field
+	}
+}

--- a/core/data/tests/test_generate_char/output.ts
+++ b/core/data/tests/test_generate_char/output.ts
@@ -1,0 +1,4 @@
+export interface MyType {
+	field: string;
+}
+

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -94,6 +94,7 @@ impl Language for Go {
             ),
             SpecialRustType::Unit => "struct{}".into(),
             SpecialRustType::String => "string".into(),
+            SpecialRustType::Char => "rune".into(),
             SpecialRustType::I8
             | SpecialRustType::U8
             | SpecialRustType::U16

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -54,6 +54,8 @@ impl Language for Kotlin {
             }
             SpecialRustType::Unit => "Unit".into(),
             SpecialRustType::String => "String".into(),
+            // Char in Kotlin is 16 bits long, so we need to use String
+            SpecialRustType::Char => "String".into(),
             // https://kotlinlang.org/docs/basic-types.html#integer-types
             SpecialRustType::I8 => "Byte".into(),
             SpecialRustType::I16 => "Short".into(),

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -95,6 +95,8 @@ impl Language for Scala {
             }
             SpecialRustType::Unit => "Unit".into(),
             SpecialRustType::String => "String".into(),
+            // Char in Scala is 16 bits long, so we need to use String
+            SpecialRustType::Char => "String".into(),
             // https://docs.scala-lang.org/scala3/book/first-look-at-types.html#scalas-value-types
             SpecialRustType::I8 => "Byte".into(),
             SpecialRustType::I16 => "Short".into(),

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -190,6 +190,7 @@ impl Language for Swift {
                 "CodableVoid".into()
             }
             SpecialRustType::String => "String".into(),
+            SpecialRustType::Char => "Unicode.Scalar".into(),
             SpecialRustType::I8 => "Int8".into(),
             SpecialRustType::U8 => "UInt8".into(),
             SpecialRustType::I16 => "Int16".into(),

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -55,6 +55,7 @@ impl Language for TypeScript {
             )),
             SpecialRustType::Unit => Ok("undefined".into()),
             SpecialRustType::String => Ok("string".into()),
+            SpecialRustType::Char => Ok("string".into()),
             SpecialRustType::I8
             | SpecialRustType::U8
             | SpecialRustType::I16

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -143,6 +143,8 @@ pub enum SpecialRustType {
     Unit,
     /// Represents `String` from the standard library
     String,
+    /// Represents `char`
+    Char,
     /// Represents `i8`
     I8,
     /// Represents `i16`
@@ -244,6 +246,7 @@ impl TryFrom<&syn::Type> for RustType {
                     // as its inner type.
                     "Box" => parameters.into_iter().next().unwrap(),
                     "bool" => Self::Special(SpecialRustType::Bool),
+                    "char" => Self::Special(SpecialRustType::Char),
                     "u8" => Self::Special(SpecialRustType::U8),
                     "u16" => Self::Special(SpecialRustType::U16),
                     "u32" => Self::Special(SpecialRustType::U32),
@@ -376,6 +379,7 @@ impl SpecialRustType {
             Self::HashMap(rty1, rty2) => rty1.contains_type(ty) || rty2.contains_type(ty),
             Self::Unit
             | Self::String
+            | Self::Char
             | Self::I8
             | Self::I16
             | Self::I32
@@ -405,6 +409,7 @@ impl SpecialRustType {
             Self::Option(_) => "Option",
             Self::HashMap(_, _) => "HashMap",
             Self::String => "String",
+            Self::Char => "char",
             Self::Bool => "bool",
             Self::I8 => "i8",
             Self::I16 => "i16",
@@ -432,6 +437,7 @@ impl SpecialRustType {
             }
             Self::Unit
             | Self::String
+            | Self::Char
             | Self::I8
             | Self::I16
             | Self::I32

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -432,6 +432,7 @@ tests! {
     enum_is_properly_named_with_serde_overrides: [swift, kotlin, scala,  typescript, go];
     can_handle_quote_in_serde_rename: [swift, kotlin, scala,  typescript, go];
     can_handle_anonymous_struct: [swift, kotlin, scala,  typescript, go];
+    test_generate_char: [swift, kotlin, scala, typescript, go];
     anonymous_struct_with_rename: [
         swift {
             prefix: "Core".to_string(),


### PR DESCRIPTION
Add support for the Rust `char` type.

Closes #103 