### PR TITLE
Support Rust slice type

### DIFF
--- a/core/data/tests/can_generate_slice_of_user_type/input.rs
+++ b/core/data/tests/can_generate_slice_of_user_type/input.rs
@@ -1,0 +1,5 @@
+#[typeshare]
+#[derive(Serialize)]
+pub struct Video<'a> {
+    pub tags: &'a [Tag],
+}

--- a/core/data/tests/can_generate_slice_of_user_type/output.go
+++ b/core/data/tests/can_generate_slice_of_user_type/output.go
@@ -1,0 +1,7 @@
+package proto
+
+import "encoding/json"
+
+type Video struct {
+	Tags []Tag `json:"tags"`
+}

--- a/core/data/tests/can_generate_slice_of_user_type/output.kt
+++ b/core/data/tests/can_generate_slice_of_user_type/output.kt
@@ -1,0 +1,12 @@
+@file:NoLiveLiterals
+
+package com.agilebits.onepassword
+
+import androidx.compose.runtime.NoLiveLiterals
+import kotlinx.serialization.*
+
+@Serializable
+data class Video (
+	val tags: List<Tag>
+)
+

--- a/core/data/tests/can_generate_slice_of_user_type/output.scala
+++ b/core/data/tests/can_generate_slice_of_user_type/output.scala
@@ -1,0 +1,9 @@
+package com.agilebits
+
+package onepassword {
+
+case class Video (
+	tags: Vector[Tag]
+)
+
+}

--- a/core/data/tests/can_generate_slice_of_user_type/output.swift
+++ b/core/data/tests/can_generate_slice_of_user_type/output.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct Video: Codable {
+	public let tags: [Tag]
+
+	public init(tags: [Tag]) {
+		self.tags = tags
+	}
+}

--- a/core/data/tests/can_generate_slice_of_user_type/output.ts
+++ b/core/data/tests/can_generate_slice_of_user_type/output.ts
@@ -1,0 +1,4 @@
+export interface Video {
+	tags: Tag[];
+}
+

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -84,6 +84,9 @@ impl Language for Go {
             SpecialRustType::Array(rtype, len) => {
                 format!("[{}]{}", len, self.format_type(rtype, generic_types)?)
             }
+            SpecialRustType::Slice(rtype) => {
+                format!("[]{}", self.format_type(rtype, generic_types)?)
+            }
             SpecialRustType::Option(rtype) => {
                 format!("*{}", self.format_type(rtype, generic_types)?)
             }

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -42,6 +42,9 @@ impl Language for Kotlin {
             SpecialRustType::Array(rtype, _) => {
                 format!("List<{}>", self.format_type(rtype, generic_types)?)
             }
+            SpecialRustType::Slice(rtype) => {
+                format!("List<{}>", self.format_type(rtype, generic_types)?)
+            }
             SpecialRustType::Option(rtype) => {
                 format!("{}?", self.format_type(rtype, generic_types)?)
             }

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -83,6 +83,9 @@ impl Language for Scala {
             SpecialRustType::Array(rtype, _) => {
                 format!("Vector[{}]", self.format_type(rtype, generic_types)?)
             }
+            SpecialRustType::Slice(rtype) => {
+                format!("Vector[{}]", self.format_type(rtype, generic_types)?)
+            }
             SpecialRustType::Option(rtype) => {
                 format!("Option[{}]", self.format_type(rtype, generic_types)?)
             }

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -177,6 +177,9 @@ impl Language for Swift {
             SpecialRustType::Array(rtype, _) => {
                 format!("[{}]", self.format_type(rtype, generic_types)?)
             }
+            SpecialRustType::Slice(rtype) => {
+                format!("[{}]", self.format_type(rtype, generic_types)?)
+            }
             SpecialRustType::Option(rtype) => {
                 format!("{}?", self.format_type(rtype, generic_types)?)
             }

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -41,6 +41,9 @@ impl Language for TypeScript {
                         .join_with(", ")
                 ))
             }
+            SpecialRustType::Slice(rtype) => {
+                Ok(format!("{}[]", self.format_type(rtype, generic_types)?))
+            }
             // We add optionality above the type formatting level
             SpecialRustType::Option(rtype) => self.format_type(rtype, generic_types),
             SpecialRustType::HashMap(rtype1, rtype2) => Ok(format!(

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -390,6 +390,7 @@ tests! {
         scala,
         typescript
     ];
+    can_generate_slice_of_user_type: [swift, kotlin, scala, typescript, go];
     can_generate_readonly_fields: [
         typescript
     ];


### PR DESCRIPTION
Adds support for the Rust slice type e.g.:

```rust
#[typeshare]
#[derive(Serialize)]
pub struct Video<'a> {
    pub tags: &'a [Tag],
}
```

@LouisGariepy please verify if it works in your case.

Closes #126