### PR TITLE
Format Args - Fix MSRV errors

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,8 +261,13 @@ fn main() {
     let parsed_data = glob_paths
         .par_iter()
         .map(|filepath| {
-            let data = std::fs::read_to_string(filepath)
-                .unwrap_or_else(|e| panic!("failed to read file at {filepath:?}: {e}"));
+            let data = std::fs::read_to_string(filepath).unwrap_or_else(|e| {
+                panic!(
+                    "failed to read file at {filepath:?}: {e}",
+                    filepath = filepath,
+                    e = e
+                )
+            });
             let parsed_data = typeshare_core::parser::parse(&data);
             if parsed_data.is_err() {
                 panic!("{}", parsed_data.err().unwrap());


### PR DESCRIPTION
Auto-captured args in fmt seems to be not as advanced in MSRV 1.57. This moves those args to explicitly named fmt args.