### PR TITLE
Draft implementation of algebraic enum without `content` attribute

### DIFF
--- a/core/data/tests/can_generate_algebraic_enum_with_named_fields/input.rs
+++ b/core/data/tests/can_generate_algebraic_enum_with_named_fields/input.rs
@@ -1,0 +1,8 @@
+#[typeshare]
+#[serde(tag = "type")]
+pub enum SomeEnum {
+    A,
+    B { field1: String },
+    C { field1: u32, field2: f32 },
+    D { field3: Option<bool> },
+}

--- a/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.kt
+++ b/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.kt
@@ -1,0 +1,23 @@
+@file:NoLiveLiterals
+
+package com.agilebits.onepassword
+
+import androidx.compose.runtime.NoLiveLiterals
+import kotlinx.serialization.*
+
+@Serializable
+sealed class SomeEnum {
+	@Serializable
+	@SerialName("A")
+	object A: SomeEnum()
+	@Serializable
+	@SerialName("B")
+	data class B(val field1: String): SomeEnum()
+	@Serializable
+	@SerialName("C")
+	data class C(val field1: UInt, val field2: Float): SomeEnum()
+	@Serializable
+	@SerialName("D")
+	data class D(val field3: Boolean?): SomeEnum()
+}
+

--- a/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.scala
+++ b/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.scala
@@ -1,0 +1,31 @@
+package com.agilebits
+
+package object onepassword {
+
+type UByte = Byte
+type UShort = Short
+type UInt = Int
+type ULong = Int
+
+}
+package onepassword {
+
+sealed trait SomeEnum {
+	def serialName: String
+}
+object SomeEnum {
+	case object A extends SomeEnum {
+		val serialName: String = "A"
+	}
+	case class B(field1: String) extends SomeEnum {
+		val serialName: String = "B"
+	}
+	case class C(field1: UInt, field2: Float) extends SomeEnum {
+		val serialName: String = "C"
+	}
+	case class D(field3: Option[Boolean]) extends SomeEnum {
+		val serialName: String = "D"
+	}
+}
+
+}

--- a/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.swift
+++ b/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum OPSomeEnum: Codable {
+	case a
+	case b(field1: String)
+	case c(field1: UInt32, field2: Float)
+	case d(field3: Bool?)
+
+	enum CodingKeys: String, CodingKey, Codable {
+		case a = "A",
+			b = "B",
+			c = "C",
+			d = "D"
+	}
+
+	private enum ContainerCodingKeys: String, CodingKey {
+		case type, field1, field2, field3
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
+		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
+			switch type {
+			case .a:
+				self = .a
+				return
+			case .b:
+				if
+					let field1 = try? container.decode(String.self, forKey: .field1)
+				{
+					self = .b(field1: field1)
+					return
+				}
+			case .c:
+				if
+					let field1 = try? container.decode(UInt32.self, forKey: .field1),
+					let field2 = try? container.decode(Float.self, forKey: .field2)
+				{
+					self = .c(field1: field1, field2: field2)
+					return
+				}
+			case .d:
+				let field3 = try? container.decodeIfPresent(Bool?.self, forKey: .field3)
+				self = .d(field3: field3)
+				return
+			}
+		}
+		throw DecodingError.typeMismatch(OPSomeEnum.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for OPSomeEnum"))
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
+		switch self {
+		case .a:
+			try container.encode(CodingKeys.a, forKey: .type)
+		case .b(let field1):
+			try container.encode(CodingKeys.b, forKey: .type)
+			try container.encode(field1, forKey: .field1)
+		case .c(let field1, let field2):
+			try container.encode(CodingKeys.c, forKey: .type)
+			try container.encode(field1, forKey: .field1)
+			try container.encode(field2, forKey: .field2)
+		case .d(let field3):
+			try container.encode(CodingKeys.d, forKey: .type)
+			try container.encode(field3, forKey: .field3)
+		}
+	}
+}

--- a/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.ts
+++ b/core/data/tests/can_generate_algebraic_enum_with_named_fields/output.ts
@@ -1,0 +1,13 @@
+export type SomeEnum = 
+	| { type: "A" }
+	| { type: "B",
+	field1: string;
+}
+	| { type: "C",
+	field1: number;
+	field2: number;
+}
+	| { type: "D",
+	field3?: boolean;
+};
+

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -388,6 +388,9 @@ func ({short_name} {full_name}) MarshalJSON() ([]byte, error) {{
                     variant_key_type = variant_key_type,
                 )
             }
+            RustEnum::FlattenedAlgebraic { .. } => {
+                panic!("Not yet implemented")
+            }
         }
     }
 

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -260,6 +260,10 @@ pub trait Language {
         e: &RustEnum,
         make_struct_name: &dyn Fn(&str) -> String,
     ) -> std::io::Result<()> {
+        if let RustEnum::FlattenedAlgebraic { .. } = e {
+            return Ok(());
+        }
+
         for (fields, shared) in e.shared().variants.iter().filter_map(|v| match v {
             RustEnumVariant::AnonymousStruct { fields, shared } => Some((fields, shared)),
             _ => None,

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -508,13 +508,37 @@ pub enum RustEnum {
         /// Shared context for this enum.
         shared: RustEnumShared,
     },
+    /// A flattened algebraic enum
+    ///
+    /// An example of such an enum:
+    ///
+    /// ```
+    /// enum AlgebraicEnum {
+    ///     UnitVariant,
+    ///     AnonymousStruct {
+    ///         field: String,
+    ///         another_field: bool,
+    ///     },
+    ///     AnonymousStruct2 {
+    ///         yet_another_field: String,
+    ///     },
+    /// }
+    /// ```
+    FlattenedAlgebraic {
+        /// The parsed value of the `#[serde(tag = "...")]` attribute
+        tag_key: String,
+        /// Shared context for this enum.
+        shared: RustEnumShared,
+    },
 }
 
 impl RustEnum {
     /// Get a reference to the inner shared content
     pub fn shared(&self) -> &RustEnumShared {
         match self {
-            Self::Unit(shared) | Self::Algebraic { shared, .. } => shared,
+            Self::Unit(shared)
+            | Self::Algebraic { shared, .. }
+            | Self::FlattenedAlgebraic { shared, .. } => shared,
         }
     }
 }

--- a/core/src/topsort.rs
+++ b/core/src/topsort.rs
@@ -68,7 +68,8 @@ fn get_enum_dependencies(
             tag_key: _,
             content_key: _,
             shared,
-        } => {
+        }
+        | RustEnum::FlattenedAlgebraic { tag_key: _, shared } => {
             if seen.insert(shared.id.original.to_string()) {
                 res.push(shared.id.original.to_string());
                 for variant in &shared.variants {
@@ -185,11 +186,8 @@ pub(crate) fn topsort(things: Vec<&RustItem>) -> Vec<&RustItem> {
     let types = HashMap::from_iter(things.iter().map(|&thing| {
         let id = match thing {
             RustItem::Enum(e) => match e {
-                RustEnum::Algebraic {
-                    tag_key: _,
-                    content_key: _,
-                    shared,
-                } => shared.id.original.clone(),
+                RustEnum::Algebraic { shared, .. } => shared.id.original.clone(),
+                RustEnum::FlattenedAlgebraic { shared, .. } => shared.id.original.clone(),
                 RustEnum::Unit(shared) => shared.id.original.clone(),
             },
             RustItem::Struct(strct) => strct.id.original.clone(),

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -366,6 +366,18 @@ tests! {
         typescript,
         go
     ];
+    can_generate_algebraic_enum_with_named_fields: [
+        swift {
+            prefix: "OP".to_string(),
+        },
+        kotlin {
+            package: "com.agilebits.onepassword".to_string(),
+        },
+        scala {
+            package: "com.agilebits.onepassword".to_string(),
+        },
+        typescript
+    ];
     can_generate_generic_enum: [
         swift {
             prefix: "Core".into(),


### PR DESCRIPTION
Draft implementation of support for Algebraic enums without specifying the `content` attribute (see https://github.com/1Password/typeshare/issues/141).

Only Unit variants and anonymous structs variants are supported (tuple variants explicitly require the content attribute), and I built support for Kotlin, Scala, Swift and TypeScript output.

This was done by adding a new `RustEnum` type (`AlgebraicFlattened`, the name is not great, I welcome any other suggestion) without the `content_key`.
