### PR TITLE
Allow to generate unions instead of TS enums in Typescript

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -34,7 +34,7 @@ The test suite can of course be run normally without updating any expectations:
 cargo test -p typeshare-core
 ```
 
-If you find yourself needing to update expectations for a specific test only, run the following (subsituting the name of your test in for the last arg):
+If you find yourself needing to update expectations for a specific test only, run the following (substituting the name of your test in for the last arg):
 
 ```
 env UPDATE_EXPECT=1 cargo test -p typeshare-core --test snapshot_tests -- can_handle_serde_rename_all::swift

--- a/core/data/tests/can_generate_unit_ts_union_enum/input.rs
+++ b/core/data/tests/can_generate_unit_ts_union_enum/input.rs
@@ -1,0 +1,18 @@
+#[typeshare(ts_union)]
+pub enum UnitEnumMultiple {
+    VariantA,
+    VariantB,
+    VariantC,
+}
+
+#[typeshare(ts_union)]
+pub enum UnitEnumOne {
+    VariantA,
+}
+
+#[typeshare(ts_union)]
+pub enum UnitEnumSkip {
+    #[typeshare(skip)]
+    VariantA,
+    VariantB,
+}

--- a/core/data/tests/can_generate_unit_ts_union_enum/output.ts
+++ b/core/data/tests/can_generate_unit_ts_union_enum/output.ts
@@ -1,0 +1,6 @@
+export type UnitEnumMultiple = "VariantA" | "VariantB" | "VariantC";
+
+export type UnitEnumOne = "VariantA";
+
+export type UnitEnumSkip = "VariantB";
+

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -183,7 +183,7 @@ impl Go {
         write_comments(w, 0, &e.shared().comments)?;
 
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 writeln!(
                     w,
                     "type {} string",

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -165,7 +165,7 @@ impl Language for Kotlin {
             .unwrap_or_default();
 
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 write!(
                     w,
                     "enum class {}{}(val string: String) ",
@@ -192,7 +192,7 @@ impl Language for Kotlin {
 impl Kotlin {
     fn write_enum_variants(&mut self, w: &mut dyn Write, e: &RustEnum) -> std::io::Result<()> {
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 for v in &shared.variants {
                     self.write_comments(w, 1, &v.shared().comments)?;
                     writeln!(w, "\t@SerialName({:?})", &v.shared().id.renamed)?;

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -193,7 +193,7 @@ impl Language for Scala {
             .unwrap_or_default();
 
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 writeln!(
                     w,
                     "sealed trait {}{} {{",
@@ -220,7 +220,7 @@ impl Language for Scala {
 impl Scala {
     fn write_enum_variants(&mut self, w: &mut dyn Write, e: &RustEnum) -> std::io::Result<()> {
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 for v in shared.variants.iter() {
                     self.write_comments(w, 1, &v.shared().comments)?;
                     writeln!(

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -436,7 +436,7 @@ impl Language for Swift {
         let enum_name =
             swift_keyword_aware_rename(&format!("{}{}", self.prefix, shared.id.renamed));
         let always_present = match e {
-            RustEnum::Unit(_) => {
+            RustEnum::Unit { .. } => {
                 let mut always_present = vec!["String".into()];
                 always_present.append(&mut self.get_default_decorators());
                 always_present
@@ -547,7 +547,7 @@ impl Swift {
         let mut coding_keys = Vec::new();
 
         match e {
-            RustEnum::Unit(shared) => {
+            RustEnum::Unit { shared, .. } => {
                 for v in &shared.variants {
                     let variant_name = v.shared().id.original.to_camel_case();
 

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -482,7 +482,11 @@ pub enum RustEnum {
     ///     Yay,
     /// }
     /// ```
-    Unit(RustEnumShared),
+    Unit {
+        /// Represents this enum in typescript as union instead of ts enum
+        ts_union: bool,
+        shared: RustEnumShared,
+    },
     /// An algebraic enum
     ///
     /// An example of such an enum:
@@ -513,7 +517,7 @@ impl RustEnum {
     /// Get a reference to the inner shared content
     pub fn shared(&self) -> &RustEnumShared {
         match self {
-            Self::Unit(shared) | Self::Algebraic { shared, .. } => shared,
+            Self::Unit { shared, .. } | Self::Algebraic { shared, .. } => shared,
         }
     }
 }

--- a/core/src/topsort.rs
+++ b/core/src/topsort.rs
@@ -63,7 +63,7 @@ fn get_enum_dependencies(
     seen: &mut HashSet<String>,
 ) {
     match enm {
-        RustEnum::Unit(_) => {}
+        RustEnum::Unit { .. } => {}
         RustEnum::Algebraic {
             tag_key: _,
             content_key: _,
@@ -185,12 +185,8 @@ pub(crate) fn topsort(things: Vec<&RustItem>) -> Vec<&RustItem> {
     let types = HashMap::from_iter(things.iter().map(|&thing| {
         let id = match thing {
             RustItem::Enum(e) => match e {
-                RustEnum::Algebraic {
-                    tag_key: _,
-                    content_key: _,
-                    shared,
-                } => shared.id.original.clone(),
-                RustEnum::Unit(shared) => shared.id.original.clone(),
+                RustEnum::Algebraic { shared, .. } => shared.id.original.clone(),
+                RustEnum::Unit { shared, .. } => shared.id.original.clone(),
             },
             RustItem::Struct(strct) => strct.id.original.clone(),
             RustItem::Alias(ta) => ta.id.original.clone(),

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -374,6 +374,7 @@ tests! {
         scala,
         typescript
     ];
+    can_generate_unit_ts_union_enum: [typescript];
     can_generate_generic_struct: [
         swift {
             prefix: "Core".into(),

--- a/docs/src/usage/annotations.md
+++ b/docs/src/usage/annotations.md
@@ -103,7 +103,24 @@ This would generate the following Kotlin code:
 typealias Options = String
 ```
 
+### TypeScript enum representation
 
+For unit enums, you can choose to generate a TypeScript union type instead
+of a TypeScript enum.
+
+```rust
+#[typeshare(ts_union)]
+pub enum UnitEnum {
+    VariantA,
+    VariantB,
+    VariantC,
+}
+```
+
+This would generate the following TypeScript code:
+```ts
+export type UnitEnum = "VariantA" | "VariantB" | "VariantC";
+```
 
 ## The `#[serde]` Attribute
 


### PR DESCRIPTION
Addresses #35

Now for unit enums, you can choose to generate a TypeScript union type instead
of a TypeScript enum.

```rust
#[typeshare(ts_union)]
pub enum UnitEnum {
    VariantA,
    VariantB,
    VariantC,
}
```

This would generate the following TypeScript code:
```ts
export type UnitEnum = "VariantA" | "VariantB" | "VariantC";
```