### PR TITLE
Add support for internally tagged non-tuple enums for Typescript

### DIFF
--- a/core/data/tests/can_generate_non_tuple_algebraic_enum_internally_tagged/input.rs
+++ b/core/data/tests/can_generate_non_tuple_algebraic_enum_internally_tagged/input.rs
@@ -1,0 +1,9 @@
+#[typeshare]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(tag = "type")]
+pub enum NonTupleAlgebraicEnum {
+    VariantA { foo: u32 },
+    VariantB { foo: u32, bar: String },
+    VariantC {},
+    VariantD,
+}

--- a/core/data/tests/can_generate_non_tuple_algebraic_enum_internally_tagged/output.ts
+++ b/core/data/tests/can_generate_non_tuple_algebraic_enum_internally_tagged/output.ts
@@ -1,0 +1,11 @@
+export type NonTupleAlgebraicEnum = 
+	| { type: "VariantA"; 
+	foo: number;
+}
+	| { type: "VariantB"; 
+	foo: number;
+	bar: string;
+}
+	| { type: "VariantC" }
+	| { type: "VariantD" };
+

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 
 use crate::language::SupportedLanguage;
 use crate::parser::ParsedData;
@@ -216,6 +216,16 @@ impl Go {
                 shared,
                 ..
             } => {
+                let content_key = content_key.as_ref().ok_or_else(|| {
+                    std::io::Error::new(
+                        ErrorKind::Other,
+                        RustTypeFormatError::SerdeContentRequired {
+                            name: shared.id.to_string(),
+                            lang: "Go".into(),
+                        },
+                    )
+                })?;
+
                 let struct_name = self.acronyms_to_uppercase(&shared.id.original);
                 let content_field = content_key.to_string().to_camel_case();
                 let tag_field = self.format_field_name(tag_key.to_string(), true);

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -9,6 +9,7 @@ use crate::{
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
+use std::io::ErrorKind;
 use std::{collections::HashMap, io::Write};
 
 /// All information needed for Kotlin type-code
@@ -209,6 +210,16 @@ impl Kotlin {
                 shared,
                 ..
             } => {
+                let content_key = content_key.as_ref().ok_or_else(|| {
+                    std::io::Error::new(
+                        ErrorKind::Other,
+                        RustTypeFormatError::SerdeContentRequired {
+                            name: shared.id.to_string(),
+                            lang: "Kotlin".into(),
+                        },
+                    )
+                })?;
+
                 for v in &shared.variants {
                     let printed_value = format!(r##""{}""##, &v.shared().id.renamed);
                     self.write_comments(w, 1, &v.shared().comments)?;

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -9,6 +9,7 @@ use crate::{
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
+use std::io::ErrorKind;
 use std::ops::Deref;
 use std::{collections::HashMap, io::Write};
 
@@ -242,6 +243,16 @@ impl Scala {
                 shared,
                 ..
             } => {
+                let content_key = content_key.as_ref().ok_or_else(|| {
+                    std::io::Error::new(
+                        ErrorKind::Other,
+                        RustTypeFormatError::SerdeContentRequired {
+                            name: shared.id.to_string(),
+                            lang: "Scala".into(),
+                        },
+                    )
+                })?;
+
                 for v in shared.variants.iter() {
                     let printed_value = format!(r##"{:?}"##, &v.shared().id.renamed);
                     self.write_comments(w, 1, &v.shared().comments)?;

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
 use std::collections::BTreeSet;
-use std::io;
+use std::io::{self, ErrorKind};
 use std::{
     collections::HashMap,
     io::Write,
@@ -502,6 +502,16 @@ impl Language for Swift {
             ..
         } = e
         {
+            let content_key = content_key.as_ref().ok_or_else(|| {
+                std::io::Error::new(
+                    ErrorKind::Other,
+                    RustTypeFormatError::SerdeContentRequired {
+                        name: shared.id.to_string(),
+                        lang: "Swift".into(),
+                    },
+                )
+            })?;
+
             writeln!(
                 w,
                 r#"
@@ -571,6 +581,16 @@ impl Swift {
                 content_key,
                 shared,
             } => {
+                let content_key = content_key.as_ref().ok_or_else(|| {
+                    std::io::Error::new(
+                        ErrorKind::Other,
+                        RustTypeFormatError::SerdeContentRequired {
+                            name: shared.id.to_string(),
+                            lang: "Swift".into(),
+                        },
+                    )
+                })?;
+
                 let generics = &shared.generic_types;
                 for v in &shared.variants {
                     self.write_comments(w, 1, &v.shared().comments)?;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -73,8 +73,6 @@ pub enum ParseError {
     SerdeContentNotAllowed { enum_ident: String },
     #[error("serde tag attribute needs to be specified for algebraic enum {enum_ident}. e.g. #[serde(tag = \"type\", content = \"content\")]")]
     SerdeTagRequired { enum_ident: String },
-    #[error("serde content attribute needs to be specified for algebraic enum {enum_ident}. e.g. #[serde(tag = \"type\", content = \"content\")]")]
-    SerdeContentRequired { enum_ident: String },
     #[error("the serde flatten attribute is not currently supported")]
     SerdeFlattenNotAllowed,
 }
@@ -316,14 +314,11 @@ fn parse_enum(e: &ItemEnum) -> Result<RustItem, ParseError> {
         let tag_key = maybe_tag_key.ok_or_else(|| ParseError::SerdeTagRequired {
             enum_ident: original_enum_ident.clone(),
         })?;
-        let content_key = maybe_content_key.ok_or_else(|| ParseError::SerdeContentRequired {
-            enum_ident: original_enum_ident.clone(),
-        })?;
 
         Ok(RustItem::Enum(RustEnum::Algebraic {
             tag_key,
-            content_key,
             shared,
+            content_key: maybe_content_key,
         }))
     }
 }

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -377,6 +377,10 @@ pub enum RustTypeFormatError {
     GenericsForbiddenInGo(String),
     #[error("Generic type `{0}` cannot be used as a map key in Typescript")]
     GenericKeyForbiddenInTS(String),
+    #[error("Serde content attribute needs to be specified for algebraic enum {name} in {lang}. e.g. #[serde(tag = \"type\", content = \"content\")]")]
+    SerdeContentRequired { name: String, lang: String },
+    #[error("Serde content attribute needs to be specified for tuple variant of algebraic enum {name} in Typescript. e.g. #[serde(tag = \"type\", content = \"content\")]")]
+    SerdeContentRequiredInTsTuple { name: String },
 }
 
 impl SpecialRustType {
@@ -503,7 +507,7 @@ pub enum RustEnum {
         /// The parsed value of the `#[serde(tag = "...")]` attribute
         tag_key: String,
         /// The parsed value of the `#[serde(content = "...")]` attribute
-        content_key: String,
+        content_key: Option<String>,
         /// Shared context for this enum.
         shared: RustEnumShared,
     },

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -366,6 +366,9 @@ tests! {
         typescript,
         go
     ];
+    can_generate_non_tuple_algebraic_enum_internally_tagged: [
+        typescript
+    ];
     can_generate_generic_enum: [
         swift {
             prefix: "Core".into(),


### PR DESCRIPTION
Currently, generating types for internally tagged enums is not possible, even though serde [supports it](https://serde.rs/enum-representations.html#internally-tagged).

This PR allows the omission of the "content" attribute while still raising errors for languages other than TypeScript. Support for additional languages may be introduced later if necessary and feasible. Additionally, it triggers an error when attempting to skip the "content" attribute for tuple enum variants in TypeScript.