### PR TITLE
Support prefixing Kotlin type names

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -14,6 +14,7 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "typeshare.toml";
 pub struct KotlinParams {
     pub package: String,
     pub module_name: String,
+    pub prefix: String,
     pub type_mappings: HashMap<String, String>,
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const ARG_TYPE: &str = "TYPE";
 const ARG_SWIFT_PREFIX: &str = "SWIFTPREFIX";
+const ARG_KOTLIN_PREFIX: &str = "KOTLINPREFIX";
 const ARG_JAVA_PACKAGE: &str = "JAVAPACKAGE";
 const ARG_MODULE_NAME: &str = "MODULENAME";
 const ARG_SCALA_PACKAGE: &str = "SCALAPACKAGE";
@@ -69,6 +70,14 @@ fn build_command() -> Command<'static> {
                 .short('s')
                 .long("swift-prefix")
                 .help("Prefix for generated Swift types")
+                .takes_value(true)
+                .required(false),
+        )
+        .arg(
+            Arg::new(ARG_KOTLIN_PREFIX)
+                .short('k')
+                .long("kotlin-prefix")
+                .help("Prefix for generated Kotlin types")
                 .takes_value(true)
                 .required(false),
         )
@@ -202,6 +211,7 @@ fn main() {
         Some(SupportedLanguage::Kotlin) => Box::new(Kotlin {
             package: config.kotlin.package,
             module_name: config.kotlin.module_name,
+            prefix: config.kotlin.prefix,
             type_mappings: config.kotlin.type_mappings,
             ..Default::default()
         }),
@@ -316,6 +326,10 @@ fn main() {
 fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
     if let Some(swift_prefix) = options.value_of(ARG_SWIFT_PREFIX) {
         config.swift.prefix = swift_prefix.to_string();
+    }
+
+    if let Some(kotlin_prefix) = options.value_of(ARG_KOTLIN_PREFIX) {
+        config.kotlin.prefix = kotlin_prefix.to_string();
     }
 
     if let Some(java_package) = options.value_of(ARG_JAVA_PACKAGE) {

--- a/core/data/tests/can_apply_prefix_correctly/output.kt
+++ b/core/data/tests/can_apply_prefix_correctly/output.kt
@@ -1,17 +1,10 @@
-@file:NoLiveLiterals
-
-package com.agilebits.onepassword
-
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
-
 @Serializable
-data class ItemDetailsFieldValue (
+data class OPItemDetailsFieldValue (
 	val hello: String
 )
 
 @Serializable
-sealed class AdvancedColors {
+sealed class OPAdvancedColors {
 	@Serializable
 	@SerialName("String")
 	data class String(val c: String): AdvancedColors()

--- a/core/data/tests/can_generate_empty_algebraic_enum/output.kt
+++ b/core/data/tests/can_generate_empty_algebraic_enum/output.kt
@@ -1,15 +1,8 @@
-@file:NoLiveLiterals
-
-package com.agilebits.onepassword
-
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+@Serializable
+object OPAddressDetails
 
 @Serializable
-object AddressDetails
-
-@Serializable
-sealed class Address {
+sealed class OPAddress {
 	@Serializable
 	@SerialName("FixedAddress")
 	data class FixedAddress(val content: AddressDetails): Address()

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -426,8 +426,8 @@ tests! {
         typescript,
         go
     ];
-    can_apply_prefix_correctly: [ swift { prefix: "OP".to_string(), }, kotlin, scala,  typescript, go ];
-    can_generate_empty_algebraic_enum: [ swift { prefix: "OP".to_string(), }, kotlin, scala,  typescript, go ];
+    can_apply_prefix_correctly: [ swift { prefix: "OP".to_string(), }, kotlin { prefix: "OP".to_string(), }, scala,  typescript, go ];
+    can_generate_empty_algebraic_enum: [ swift { prefix: "OP".to_string(), }, kotlin { prefix: "OP".to_string(), }, scala,  typescript, go ];
     can_generate_algebraic_enum_with_skipped_variants: [swift, kotlin, scala,  typescript, go];
     can_generate_struct_with_skipped_fields: [swift, kotlin, scala,  typescript, go];
     enum_is_properly_named_with_serde_overrides: [swift, kotlin, scala,  typescript, go];


### PR DESCRIPTION
Supports prefixing Kotlin type names with a new `kotlin-prefix` argument that can be supplied when using the typeshare tool.

Resolves https://github.com/1Password/typeshare/issues/158/