### PR TITLE
Fix mdbook github action

### DIFF
--- a/.github/workflows/docdeploy.yml
+++ b/.github/workflows/docdeploy.yml
@@ -9,17 +9,12 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - 1.57.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
-      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.4" mdbook)
+      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install  mdbook)
       - run: mdbook build docs
       - uses: JamesIves/github-pages-deploy-action@4.1.7
         with:

--- a/.github/workflows/docdeploy.yml
+++ b/.github/workflows/docdeploy.yml
@@ -11,11 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install  mdbook)
+      - run: (test -x $HOME/.cargo/bin/mdbook || cargo install mdbook)
       - run: mdbook build docs
       - uses: JamesIves/github-pages-deploy-action@4.1.7
         with:

--- a/.github/workflows/docdeploy.yml
+++ b/.github/workflows/docdeploy.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          toolchain: stable
       - run: (test -x $HOME/.cargo/bin/mdbook || cargo install  mdbook)
       - run: mdbook build docs
       - uses: JamesIves/github-pages-deploy-action@4.1.7


### PR DESCRIPTION
We probably don't have to use the MSRV for the github mdbook action. Right now it is broken and this fixes it. `actions-rs` was also failing and I noticed the project is [archived](https://github.com/actions-rs). Switching to [`actions-rust-lang`](https://github.com/actions-rust-lang/setup-rust-toolchain) with the changes below gets the action running correctly once again.