### PR TITLE
Fixes inner Kotlin classes incorrectly referencing superclass without prefix

### DIFF
--- a/core/data/tests/can_apply_prefix_correctly/output.kt
+++ b/core/data/tests/can_apply_prefix_correctly/output.kt
@@ -7,21 +7,21 @@ data class OPItemDetailsFieldValue (
 sealed class OPAdvancedColors {
 	@Serializable
 	@SerialName("String")
-	data class String(val c: String): AdvancedColors()
+	data class String(val c: String): OPAdvancedColors()
 	@Serializable
 	@SerialName("Number")
-	data class Number(val c: Int): AdvancedColors()
+	data class Number(val c: Int): OPAdvancedColors()
 	@Serializable
 	@SerialName("NumberArray")
-	data class NumberArray(val c: List<Int>): AdvancedColors()
+	data class NumberArray(val c: List<Int>): OPAdvancedColors()
 	@Serializable
 	@SerialName("ReallyCoolType")
-	data class ReallyCoolType(val c: ItemDetailsFieldValue): AdvancedColors()
+	data class ReallyCoolType(val c: OPItemDetailsFieldValue): OPAdvancedColors()
 	@Serializable
 	@SerialName("ArrayReallyCoolType")
-	data class ArrayReallyCoolType(val c: List<ItemDetailsFieldValue>): AdvancedColors()
+	data class ArrayReallyCoolType(val c: List<OPItemDetailsFieldValue>): OPAdvancedColors()
 	@Serializable
 	@SerialName("DictionaryReallyCoolType")
-	data class DictionaryReallyCoolType(val c: HashMap<String, ItemDetailsFieldValue>): AdvancedColors()
+	data class DictionaryReallyCoolType(val c: HashMap<String, OPItemDetailsFieldValue>): OPAdvancedColors()
 }
 

--- a/core/data/tests/can_generate_empty_algebraic_enum/output.kt
+++ b/core/data/tests/can_generate_empty_algebraic_enum/output.kt
@@ -5,9 +5,9 @@ object OPAddressDetails
 sealed class OPAddress {
 	@Serializable
 	@SerialName("FixedAddress")
-	data class FixedAddress(val content: AddressDetails): Address()
+	data class FixedAddress(val content: OPAddressDetails): OPAddress()
 	@Serializable
 	@SerialName("NoFixedAddress")
-	object NoFixedAddress: Address()
+	object NoFixedAddress: OPAddress()
 }
 

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -32,6 +32,20 @@ impl Language for Kotlin {
         &self.type_mappings
     }
 
+    fn format_simple_type(
+        &mut self,
+        base: &String,
+        generic_types: &[String],
+    ) -> Result<String, RustTypeFormatError> {
+        Ok(if let Some(mapped) = self.type_map().get(base) {
+            mapped.into()
+        } else if generic_types.contains(base) {
+            base.into()
+        } else {
+            format!("{}{}", self.prefix, base)
+        })
+    }
+
     fn format_special_type(
         &mut self,
         special_ty: &SpecialRustType,
@@ -156,11 +170,9 @@ impl Language for Kotlin {
     }
 
     fn write_enum(&mut self, w: &mut dyn Write, e: &RustEnum) -> std::io::Result<()> {
-        let type_name = format!("{}{}", &self.prefix, &e.shared().id.renamed);
-
         // Generate named types for any anonymous struct variants of this enum
         self.write_types_for_anonymous_structs(w, e, &|variant_name| {
-            format!("{}{}Inner", type_name, variant_name)
+            format!("{}{}Inner", &e.shared().id.renamed, variant_name)
         })?;
 
         self.write_comments(w, 0, &e.shared().comments)?;
@@ -174,12 +186,12 @@ impl Language for Kotlin {
             RustEnum::Unit(..) => {
                 write!(
                     w,
-                    "enum class {}{}(val string: String) ",
-                    type_name, generic_parameters
+                    "enum class {}{}{}(val string: String) ",
+                    self.prefix, &e.shared().id.renamed, generic_parameters
                 )?;
             }
             RustEnum::Algebraic { .. } => {
-                write!(w, "sealed class {}{} ", type_name, generic_parameters)?;
+                write!(w, "sealed class {}{}{} ", self.prefix, &e.shared().id.renamed, generic_parameters)?;
             }
         }
 
@@ -285,8 +297,9 @@ impl Kotlin {
 
                             write!(
                                 w,
-                                "val {}: {}{}Inner{}",
+                                "val {}: {}{}{}Inner{}",
                                 content_key,
+                                self.prefix,
                                 e.shared().id.original,
                                 shared.id.original,
                                 generics,
@@ -297,7 +310,8 @@ impl Kotlin {
 
                     writeln!(
                         w,
-                        ": {}{}()",
+                        ": {}{}{}()",
+                        self.prefix,
                         e.shared().id.original,
                         (!e.shared().generic_types.is_empty())
                             .then(|| format!("<{}>", e.shared().generic_types.join(", ")))

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -187,11 +187,19 @@ impl Language for Kotlin {
                 write!(
                     w,
                     "enum class {}{}{}(val string: String) ",
-                    self.prefix, &e.shared().id.renamed, generic_parameters
+                    self.prefix,
+                    &e.shared().id.renamed,
+                    generic_parameters
                 )?;
             }
             RustEnum::Algebraic { .. } => {
-                write!(w, "sealed class {}{}{} ", self.prefix, &e.shared().id.renamed, generic_parameters)?;
+                write!(
+                    w,
+                    "sealed class {}{}{} ",
+                    self.prefix,
+                    &e.shared().id.renamed,
+                    generic_parameters
+                )?;
             }
         }
 


### PR DESCRIPTION
Addresses an issue where inner Kotlin classes incorrectly references the super class without using the prefix. This caused compilation errors as it can't find its super class.

Closes https://github.com/1Password/typeshare/issues/164