### PR TITLE
Update Cargo.lock for v1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "expect-test",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "clap",
  "clap_complete_command",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "expect-test",


### PR DESCRIPTION
Update Cargo.lock to use typeshare v1.9.1