### PR TITLE
Remove Kotlin compose dependency and star imports

### DIFF
--- a/core/data/tests/anonymous_struct_with_rename/output.kt
+++ b/core/data/tests/anonymous_struct_with_rename/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// Generated type representing the anonymous struct variant `List` of the `AnonymousStructWithRename` Rust enum
 @Serializable

--- a/core/data/tests/can_generate_algebraic_enum/output.kt
+++ b/core/data/tests/can_generate_algebraic_enum/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// Struct comment
 @Serializable

--- a/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.kt
+++ b/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 sealed class SomeEnum {

--- a/core/data/tests/can_generate_bare_string_enum/output.kt
+++ b/core/data/tests/can_generate_bare_string_enum/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/can_generate_generic_enum/output.kt
+++ b/core/data/tests/can_generate_generic_enum/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 sealed class GenericEnum<A, B> {

--- a/core/data/tests/can_generate_generic_struct/output.kt
+++ b/core/data/tests/can_generate_generic_struct/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class GenericStruct<A, B> (

--- a/core/data/tests/can_generate_generic_type_alias/output.kt
+++ b/core/data/tests/can_generate_generic_type_alias/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias GenericTypeAlias<T> = List<T>
 

--- a/core/data/tests/can_generate_simple_enum/output.kt
+++ b/core/data/tests/can_generate_simple_enum/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 /// Continued lovingly here

--- a/core/data/tests/can_generate_simple_struct_with_a_comment/output.kt
+++ b/core/data/tests/can_generate_simple_struct_with_a_comment/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object Location

--- a/core/data/tests/can_generate_slice_of_user_type/output.kt
+++ b/core/data/tests/can_generate_slice_of_user_type/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class Video (

--- a/core/data/tests/can_generate_struct_with_skipped_fields/output.kt
+++ b/core/data/tests/can_generate_struct_with_skipped_fields/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class MyStruct (

--- a/core/data/tests/can_generate_unit_structs/output.kt
+++ b/core/data/tests/can_generate_unit_structs/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object UnitStruct

--- a/core/data/tests/can_handle_anonymous_struct/output.kt
+++ b/core/data/tests/can_handle_anonymous_struct/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// Generated type representing the anonymous struct variant `Us` of the `AutofilledBy` Rust enum
 @Serializable

--- a/core/data/tests/can_handle_quote_in_serde_rename/output.kt
+++ b/core/data/tests/can_handle_quote_in_serde_rename/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/can_handle_serde_rename/output.kt
+++ b/core/data/tests/can_handle_serde_rename/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object OtherType

--- a/core/data/tests/can_handle_serde_rename_all/output.kt
+++ b/core/data/tests/can_handle_serde_rename_all/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a Person struct with camelCase rename
 @Serializable

--- a/core/data/tests/can_handle_serde_rename_on_top_level/output.kt
+++ b/core/data/tests/can_handle_serde_rename_on_top_level/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object OtherType

--- a/core/data/tests/can_handle_unit_type/output.kt
+++ b/core/data/tests/can_handle_unit_type/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This struct has a unit field
 @Serializable

--- a/core/data/tests/can_override_types/output.kt
+++ b/core/data/tests/can_override_types/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class OverrideStruct (

--- a/core/data/tests/can_recognize_types_inside_modules/output.kt
+++ b/core/data/tests/can_recognize_types_inside_modules/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class A (

--- a/core/data/tests/enum_is_properly_named_with_serde_overrides/output.kt
+++ b/core/data/tests/enum_is_properly_named_with_serde_overrides/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 /// Continued lovingly here

--- a/core/data/tests/generate_types/output.kt
+++ b/core/data/tests/generate_types/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object CustomType

--- a/core/data/tests/generates_empty_structs_and_initializers/output.kt
+++ b/core/data/tests/generates_empty_structs_and_initializers/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object MyEmptyStruct

--- a/core/data/tests/kebab_case_rename/output.kt
+++ b/core/data/tests/kebab_case_rename/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/orders_types/output.kt
+++ b/core/data/tests/orders_types/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class A (

--- a/core/data/tests/recursive_enum_decorator/output.kt
+++ b/core/data/tests/recursive_enum_decorator/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 sealed class Options {

--- a/core/data/tests/resolves_qualified_type/output.kt
+++ b/core/data/tests/resolves_qualified_type/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class QualifiedTypes (

--- a/core/data/tests/serialize_anonymous_field_as/output.kt
+++ b/core/data/tests/serialize_anonymous_field_as/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 sealed class SomeEnum {

--- a/core/data/tests/serialize_field_as/output.kt
+++ b/core/data/tests/serialize_field_as/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class EditItemViewModelSaveRequest (

--- a/core/data/tests/serialize_type_alias/output.kt
+++ b/core/data/tests/serialize_type_alias/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias AlsoString = String
 

--- a/core/data/tests/smart_pointers/output.kt
+++ b/core/data/tests/smart_pointers/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/test_algebraic_enum_case_name_support/output.kt
+++ b/core/data/tests/test_algebraic_enum_case_name_support/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object ItemDetailsFieldValue

--- a/core/data/tests/test_generate_char/output.kt
+++ b/core/data/tests/test_generate_char/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class MyType (

--- a/core/data/tests/test_i54_u53_type/output.kt
+++ b/core/data/tests/test_i54_u53_type/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class Foo (

--- a/core/data/tests/test_optional_type_alias/output.kt
+++ b/core/data/tests/test_optional_type_alias/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias OptionalU32 = UInt?
 

--- a/core/data/tests/test_serde_default_struct/output.kt
+++ b/core/data/tests/test_serde_default_struct/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class Foo (

--- a/core/data/tests/test_serde_iso8601/output.kt
+++ b/core/data/tests/test_serde_iso8601/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class Foo (

--- a/core/data/tests/test_serde_url/output.kt
+++ b/core/data/tests/test_serde_url/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 data class Foo (

--- a/core/data/tests/test_serialized_as/output.kt
+++ b/core/data/tests/test_serialized_as/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias ItemId = String
 

--- a/core/data/tests/test_serialized_as_tuple/output.kt
+++ b/core/data/tests/test_serialized_as_tuple/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias ItemId = String
 

--- a/core/data/tests/test_simple_enum_case_name_support/output.kt
+++ b/core/data/tests/test_simple_enum_case_name_support/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/data/tests/test_type_alias/output.kt
+++ b/core/data/tests/test_type_alias/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 typealias Bar = String
 

--- a/core/data/tests/use_correct_decoded_variable_name/output.kt
+++ b/core/data/tests/use_correct_decoded_variable_name/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 @Serializable
 object MyEmptyStruct

--- a/core/data/tests/use_correct_integer_types/output.kt
+++ b/core/data/tests/use_correct_integer_types/output.kt
@@ -1,9 +1,7 @@
-@file:NoLiveLiterals
-
 package com.agilebits.onepassword
 
-import androidx.compose.runtime.NoLiveLiterals
-import kotlinx.serialization.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
 
 /// This is a comment.
 @Serializable

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -99,12 +99,10 @@ impl Language for Kotlin {
                 writeln!(w, " */")?;
                 writeln!(w)?;
             }
-            writeln!(w, "@file:NoLiveLiterals")?;
-            writeln!(w)?;
             writeln!(w, "package {}", self.package)?;
             writeln!(w)?;
-            writeln!(w, "import androidx.compose.runtime.NoLiveLiterals")?;
-            writeln!(w, "import kotlinx.serialization.*")?;
+            writeln!(w, "import kotlinx.serialization.Serializable")?;
+            writeln!(w, "import kotlinx.serialization.SerialName")?;
             writeln!(w)?;
         }
 


### PR DESCRIPTION
This PR makes two minor changes to the generated Kotlin code:

- The usage `androidx.compose.runtime.NoLiveLiterals` creates an unnecessary dependency on the Jetpack Compose runtime in our generated types module. It also isn't needed because there are no literals in the generated output.
- Usage of wildcard/star imports is discouraged. Updated to import the specific serialization dependencies we use to be consistent with Kotlin best practices. 