### PR TITLE
Decorator to redact Kotlin toString

### DIFF
--- a/core/data/tests/struct_decorator/input.rs
+++ b/core/data/tests/struct_decorator/input.rs
@@ -15,7 +15,7 @@ pub struct BestHockeyTeams2 {
     Lies: String,
 }
 
-#[typeshare(kotlin = "idk")]
+#[typeshare(kotlin = "redacted_to_string")]
 pub struct BestHockeyTeams3 {
     PittsburghPenguins: u32,
     Lies: String,

--- a/core/data/tests/struct_decorator/output.kt
+++ b/core/data/tests/struct_decorator/output.kt
@@ -1,0 +1,37 @@
+package com.agilebits.onepassword
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+data class BestHockeyTeams (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+)
+
+@Serializable
+data class BestHockeyTeams1 (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+)
+
+@Serializable
+data class BestHockeyTeams2 (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+)
+
+@Serializable
+data class BestHockeyTeams3 (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+) {
+	override fun toString(): String = "BestHockeyTeams3"
+}
+
+@Serializable
+data class BestHockeyTeams4 (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+)
+

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -11,6 +11,8 @@ use joinery::JoinableIterator;
 use lazy_format::lazy_format;
 use std::{collections::HashMap, io::Write};
 
+const REDACTED_TO_STRING: &str = "redacted_to_string";
+
 /// All information needed for Kotlin type-code
 #[derive(Default)]
 pub struct Kotlin {
@@ -162,7 +164,16 @@ impl Language for Kotlin {
                 self.write_element(w, last, rs.generic_types.as_slice(), requires_serial_name)?;
                 writeln!(w)?;
             }
-            writeln!(w, ")\n")?;
+            write!(w, ")")?;
+            if let Some(kotlin_decorators) = rs.decorators.get(&SupportedLanguage::Kotlin) {
+                let redacted_decorator = String::from(REDACTED_TO_STRING);
+                if kotlin_decorators.iter().any(|d| *d == redacted_decorator) {
+                    writeln!(w, " {{")?;
+                    writeln!(w, "\toverride fun toString(): String = {:?}", rs.id.renamed)?;
+                    write!(w, "}}")?;
+                }
+            }
+            writeln!(w, "\n")?;
         }
         Ok(())
     }

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -295,7 +295,7 @@ pub trait Language {
                         &shared.id.original,
                         &e.shared().id.original,
                     )],
-                    decorators: HashMap::new(),
+                    decorators: e.shared().decorators.clone(),
                 },
             )?;
         }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -676,6 +676,14 @@ fn get_decorators(attrs: &[syn::Attribute]) -> HashMap<SupportedLanguage, Vec<St
         decs.dedup(); //removing any duplicates just in case
     }
 
+    for value in get_name_value_meta_items(attrs, "kotlin", TYPESHARE) {
+        let decorators: Vec<String> = value.split(',').map(|s| s.trim().to_string()).collect();
+        let decs = out.entry(SupportedLanguage::Kotlin).or_default();
+        decs.extend(decorators);
+        decs.sort_unstable();
+        decs.dedup(); //removing any duplicates just in case
+    }
+
     //return our hashmap mapping of language -> Vec<decorators>
     out
 }

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -541,7 +541,7 @@ tests! {
     //3 tests for adding decorators to enums and structs
     const_enum_decorator: [ swift{ prefix: "OP".to_string(), } ];
     algebraic_enum_decorator: [ swift{ prefix: "OP".to_string(), } ];
-    struct_decorator: [ swift{ prefix: "OP".to_string(), } ];
+    struct_decorator: [ kotlin, swift{ prefix: "OP".to_string(), } ];
     serialize_field_as: [kotlin, swift, typescript, scala,  go];
     serialize_type_alias: [kotlin, swift, typescript, scala,  go];
     serialize_anonymous_field_as: [kotlin, swift, typescript, scala,  go];


### PR DESCRIPTION
Adds a Kotlin-language specific decorator in order to generate a custom `toString` function on data classes where all the field data removed. This is a guard to avoid potentially leaking sensitive data to logs via the default `toString` function.