### PR TITLE
Allow swift decorator constraints to apply to generics

### DIFF
--- a/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
@@ -1,0 +1,17 @@
+#[typeshare(swift = "Equatable")]
+pub struct Button<T> {
+    /// Label of the button
+    pub label: String,
+    /// Accessibility label if it needed to be different than label
+    pub accessibility_label: Option<String>,
+    /// Optional tooltips that provide extra explanation for a button
+    pub tooltip: Option<String>,
+    /// Button action if there one
+    pub action: Option<T>,
+    /// Icon if there is one
+    pub icon: Option<Icon>,
+    /// Button state
+    pub state: ButtonState,
+    /// Button Mode
+    pub style: ButtonStyle,
+}

--- a/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public struct Button<T: Codable & Equatable>: Codable, Equatable {
+	/// Label of the button
+	public let label: String
+	/// Accessibility label if it needed to be different than label
+	public let accessibility_label: String?
+	/// Optional tooltips that provide extra explanation for a button
+	public let tooltip: String?
+	/// Button action if there one
+	public let action: T?
+	/// Icon if there is one
+	public let icon: Icon?
+	/// Button state
+	public let state: ButtonState
+	/// Button Mode
+	public let style: ButtonStyle
+
+	public init(label: String, accessibility_label: String?, tooltip: String?, action: T?, icon: Icon?, state: ButtonState, style: ButtonStyle) {
+		self.label = label
+		self.accessibility_label = accessibility_label
+		self.tooltip = tooltip
+		self.action = action
+		self.icon = icon
+		self.state = state
+		self.style = style
+	}
+}

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -278,7 +278,13 @@ impl Language for Swift {
                 .for_each(|d| decs.push(d.clone()));
         }
 
-        let generic_constraint_string = default_generic_constraints.get_constraints().join(" & ");
+        // Include any decorator constraints on the generic types.
+        let generic_constraint_string = default_generic_constraints
+            .get_constraints()
+            .chain(decs.iter())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .join(" & ");
 
         writeln!(
             w,

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -452,10 +452,15 @@ impl Language for Swift {
 
         self.write_comments(w, 0, &shared.comments)?;
         let indirect = if shared.is_recursive { "indirect " } else { "" };
+
         let generic_constraint_string = self
             .default_generic_constraints
             .get_constraints()
+            .chain(decs.iter())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
             .join(" & ");
+
         writeln!(
             w,
             "public {}enum {}{}: {} {{",

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -569,4 +569,5 @@ tests! {
         go
     ];
     can_generate_anonymous_struct_with_skipped_fields: [swift, kotlin, scala, typescript, go];
+    generic_struct_with_constraints_and_decorators: [swift];
 }


### PR DESCRIPTION
Allow `#[typeshare(swift = "Constraint")]` to be applied to generic members.

Example in included test case.