### PR TITLE
allow defining generic type constraints for swift

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -34,6 +34,8 @@ pub struct SwiftParams {
     pub type_mappings: HashMap<String, String>,
     pub default_decorators: Vec<String>,
     pub default_generic_constraints: Vec<String>,
+    /// The contraints to apply to `CodableVoid`.
+    pub codablevoid_constraints: Vec<String>,
 }
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -146,6 +146,7 @@ fn language(
                 config.swift.default_generic_constraints,
             ),
             multi_file,
+            codablevoid_constraints: config.swift.codablevoid_constraints,
             ..Default::default()
         }),
         SupportedLanguage::Kotlin => Box::new(Kotlin {

--- a/core/data/tests/can_generate_generic_struct/output.swift
+++ b/core/data/tests/can_generate_generic_struct/output.swift
@@ -88,4 +88,4 @@ public enum CoreEnumUsingGenericStruct: Codable {
 }
 
 /// () isn't codable, so we use this instead to represent Rust's unit type
-public struct CodableVoid: Codable {}
+public struct CodableVoid: Codable, Equatable {}

--- a/core/data/tests/can_handle_unit_type/output.swift
+++ b/core/data/tests/can_handle_unit_type/output.swift
@@ -46,4 +46,4 @@ public enum EnumHasVoidType: Codable {
 }
 
 /// () isn't codable, so we use this instead to represent Rust's unit type
-public struct CodableVoid: Codable {}
+public struct CodableVoid: Codable, Equatable {}

--- a/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
@@ -2,9 +2,9 @@
     swift = "Equatable, Identifiable",
     swiftGenericConstraints = "T: Equatable & SomeThingElse, V: Equatable"
 )]
-pub struct Button<T, V> {
+pub struct Button<T, V, I> {
     /// Label of the button
-    pub label: String,
+    pub label: I,
     /// Accessibility label if it needed to be different than label
     pub accessibility_label: Option<String>,
     /// Optional tooltips that provide extra explanation for a button
@@ -18,3 +18,9 @@ pub struct Button<T, V> {
     /// Button Mode
     pub style: ButtonStyle,
 }
+
+#[typeshare]
+pub struct ButtonState;
+
+#[typeshare]
+pub struct ButtonStyle;

--- a/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/input.rs
@@ -1,5 +1,8 @@
-#[typeshare(swift = "Equatable")]
-pub struct Button<T> {
+#[typeshare(
+    swift = "Equatable, Identifiable",
+    swiftGenericConstraints = "T: Equatable & SomeThingElse, V: Equatable"
+)]
+pub struct Button<T, V> {
     /// Label of the button
     pub label: String,
     /// Accessibility label if it needed to be different than label
@@ -9,7 +12,7 @@ pub struct Button<T> {
     /// Button action if there one
     pub action: Option<T>,
     /// Icon if there is one
-    pub icon: Option<Icon>,
+    pub icon: Option<V>,
     /// Button state
     pub state: ButtonState,
     /// Button Mode

--- a/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
@@ -1,8 +1,16 @@
 import Foundation
 
-public struct Button<T: Codable & Equatable & SomeThingElse, V: Codable & Equatable>: Codable, Equatable, Identifiable {
+public struct ButtonState: Codable {
+	public init() {}
+}
+
+public struct ButtonStyle: Codable {
+	public init() {}
+}
+
+public struct Button<T: Codable & Equatable & SomeThingElse, V: Codable & Equatable, I: Codable>: Codable, Equatable, Identifiable {
 	/// Label of the button
-	public let label: String
+	public let label: I
 	/// Accessibility label if it needed to be different than label
 	public let accessibility_label: String?
 	/// Optional tooltips that provide extra explanation for a button
@@ -16,7 +24,7 @@ public struct Button<T: Codable & Equatable & SomeThingElse, V: Codable & Equata
 	/// Button Mode
 	public let style: ButtonStyle
 
-	public init(label: String, accessibility_label: String?, tooltip: String?, action: T?, icon: V?, state: ButtonState, style: ButtonStyle) {
+	public init(label: I, accessibility_label: String?, tooltip: String?, action: T?, icon: V?, state: ButtonState, style: ButtonStyle) {
 		self.label = label
 		self.accessibility_label = accessibility_label
 		self.tooltip = tooltip

--- a/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
+++ b/core/data/tests/generic_struct_with_constraints_and_decorators/output.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct Button<T: Codable & Equatable>: Codable, Equatable {
+public struct Button<T: Codable & Equatable & SomeThingElse, V: Codable & Equatable>: Codable, Equatable, Identifiable {
 	/// Label of the button
 	public let label: String
 	/// Accessibility label if it needed to be different than label
@@ -10,13 +10,13 @@ public struct Button<T: Codable & Equatable>: Codable, Equatable {
 	/// Button action if there one
 	public let action: T?
 	/// Icon if there is one
-	public let icon: Icon?
+	public let icon: V?
 	/// Button state
 	public let state: ButtonState
 	/// Button Mode
 	public let style: ButtonStyle
 
-	public init(label: String, accessibility_label: String?, tooltip: String?, action: T?, icon: Icon?, state: ButtonState, style: ButtonStyle) {
+	public init(label: String, accessibility_label: String?, tooltip: String?, action: T?, icon: V?, state: ButtonState, style: ButtonStyle) {
 		self.label = label
 		self.accessibility_label = accessibility_label
 		self.tooltip = tooltip

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -1,6 +1,6 @@
 use super::{Language, ScopedCrateTypes};
 use crate::language::SupportedLanguage;
-use crate::parser::{remove_dash_from_identifier, ParsedData, KOTLIN_DECORATOR};
+use crate::parser::{remove_dash_from_identifier, DecoratorKind, ParsedData};
 use crate::rust_types::{RustTypeFormatError, SpecialRustType};
 use crate::{
     rename::RenameExt,
@@ -169,11 +169,7 @@ impl Language for Kotlin {
                 writeln!(w)?;
             }
             write!(w, ")")?;
-            if let Some(kotlin_decorators) = rs
-                .decorators
-                .get(&SupportedLanguage::Kotlin)
-                .and_then(|d| d.get(KOTLIN_DECORATOR))
-            {
+            if let Some(kotlin_decorators) = rs.decorators.get(&DecoratorKind::Kotlin) {
                 let redacted_decorator = String::from(REDACTED_TO_STRING);
                 if kotlin_decorators.iter().any(|d| *d == redacted_decorator) {
                     writeln!(w, " {{")?;

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -1,6 +1,6 @@
 use super::{Language, ScopedCrateTypes};
 use crate::language::SupportedLanguage;
-use crate::parser::{remove_dash_from_identifier, ParsedData};
+use crate::parser::{remove_dash_from_identifier, ParsedData, KOTLIN_DECORATOR};
 use crate::rust_types::{RustTypeFormatError, SpecialRustType};
 use crate::{
     rename::RenameExt,
@@ -169,7 +169,11 @@ impl Language for Kotlin {
                 writeln!(w)?;
             }
             write!(w, ")")?;
-            if let Some(kotlin_decorators) = rs.decorators.get(&SupportedLanguage::Kotlin) {
+            if let Some(kotlin_decorators) = rs
+                .decorators
+                .get(&SupportedLanguage::Kotlin)
+                .and_then(|d| d.get(KOTLIN_DECORATOR))
+            {
                 let redacted_decorator = String::from(REDACTED_TO_STRING);
                 if kotlin_decorators.iter().any(|d| *d == redacted_decorator) {
                     writeln!(w, " {{")?;

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -242,8 +242,7 @@ impl Language for Swift {
         self.write_comments(w, 0, &ty.comments)?;
 
         let swift_prefix = &self.prefix;
-        let type_name =
-            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", swift_prefix, ty.id.renamed)));
+        let type_name = swift_keyword_aware_rename(format!("{}{}", swift_prefix, ty.id.renamed));
 
         writeln!(
             w,
@@ -266,8 +265,7 @@ impl Language for Swift {
         writeln!(w)?;
         self.write_comments(w, 0, &rs.comments)?;
 
-        let type_name =
-            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", self.prefix, rs.id.renamed)));
+        let type_name = swift_keyword_aware_rename(format!("{}{}", self.prefix, rs.id.renamed));
 
         // If there are no decorators found for this struct, still write `Codable` and default decorators for structs
         // Check if this struct's decorators contains swift in the hashmap
@@ -310,9 +308,7 @@ impl Language for Swift {
             if f.id.renamed.chars().any(|c| c == '-') {
                 coding_keys.push(format!(
                     r##"{} = "{}""##,
-                    remove_dash_from_identifier(
-                        swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
-                    ),
+                    remove_dash_from_identifier(swift_keyword_aware_rename(&f.id.renamed).as_ref()),
                     &f.id.renamed
                 ));
 
@@ -321,7 +317,7 @@ impl Language for Swift {
                 should_write_coding_keys = true;
             } else {
                 coding_keys.push(remove_dash_from_identifier(
-                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref(),
+                    swift_keyword_aware_rename(&f.id.renamed).as_ref(),
                 ));
             }
 
@@ -335,9 +331,7 @@ impl Language for Swift {
             writeln!(
                 w,
                 "\tpublic let {}: {}{}",
-                remove_dash_from_identifier(
-                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
-                ),
+                remove_dash_from_identifier(swift_keyword_aware_rename(&f.id.renamed).as_ref()),
                 case_type,
                 (f.has_default && !f.ty.is_optional())
                     .then_some("?")
@@ -385,9 +379,7 @@ impl Language for Swift {
                 w,
                 "\n\t\tself.{} = {}",
                 remove_dash_from_identifier(&f.id.renamed),
-                remove_dash_from_identifier(
-                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
-                )
+                remove_dash_from_identifier(swift_keyword_aware_rename(&f.id.renamed).as_ref())
             )?;
         }
         if !rs.fields.is_empty() {
@@ -424,8 +416,7 @@ impl Language for Swift {
         }
 
         let shared = e.shared();
-        let enum_name =
-            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", self.prefix, shared.id.renamed)));
+        let enum_name = swift_keyword_aware_rename(format!("{}{}", self.prefix, shared.id.renamed));
         let always_present = match e {
             RustEnum::Unit(_) => ["String"]
                 .into_iter()
@@ -560,17 +551,13 @@ impl Swift {
                     self.write_comments(w, 1, &v.shared().comments)?;
                     if v.shared().id.renamed == variant_name {
                         // We don't need to handle any renaming
-                        writeln!(
-                            w,
-                            "\tcase {}",
-                            &swift_keyword_aware_rename(Cow::Borrowed(&variant_name))
-                        )?;
+                        writeln!(w, "\tcase {}", &swift_keyword_aware_rename(&variant_name))?;
                     } else {
                         // We do need to handle renaming
                         writeln!(
                             w,
                             "\tcase {} = {:?}",
-                            swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
+                            swift_keyword_aware_rename(&variant_name),
                             &v.shared().id.renamed
                         )?;
                     }
@@ -603,20 +590,16 @@ impl Swift {
                     };
 
                     coding_keys.push(if variant_name == v.shared().id.renamed {
-                        swift_keyword_aware_rename(Cow::Borrowed(&variant_name)).into_owned()
+                        swift_keyword_aware_rename(&variant_name).into_owned()
                     } else {
                         format!(
                             r##"{} = "{}""##,
-                            swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
+                            swift_keyword_aware_rename(&variant_name),
                             &v.shared().id.renamed
                         )
                     });
 
-                    write!(
-                        w,
-                        "\tcase {}",
-                        swift_keyword_aware_rename(Cow::Borrowed(&variant_name))
-                    )?;
+                    write!(w, "\tcase {}", swift_keyword_aware_rename(&variant_name))?;
 
                     match v {
                         RustEnumVariant::Unit(_) => {
@@ -633,8 +616,7 @@ impl Swift {
 		case .{case_name}:
 			try container.encode(CodingKeys.{case_name}, forKey: .{tag_key})",
                                 tag_key = tag_key,
-                                case_name =
-                                    swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
+                                case_name = swift_keyword_aware_rename(&variant_name),
                             ));
                         }
                         RustEnumVariant::Tuple { ty, .. } => {
@@ -642,11 +624,7 @@ impl Swift {
                             let case_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
                                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                            write!(
-                                w,
-                                "({})",
-                                swift_keyword_aware_rename(Cow::Borrowed(&case_type))
-                            )?;
+                            write!(w, "({})", swift_keyword_aware_rename(&case_type))?;
 
                             if content_optional {
                                 decoding_cases.push(format!(
@@ -661,8 +639,7 @@ impl Swift {
 					return
 				}}",
                                     content_key = content_key,
-                                    case_type =
-                                        swift_keyword_aware_rename(Cow::Borrowed(&case_type)),
+                                    case_type = swift_keyword_aware_rename(&case_type),
                                     case_name = &variant_name
                                 ))
                             } else {
@@ -674,8 +651,7 @@ impl Swift {
 					return
 				}}",
                                     content_key = content_key,
-                                    case_type =
-                                        swift_keyword_aware_rename(Cow::Borrowed(&case_type)),
+                                    case_type = swift_keyword_aware_rename(&case_type),
                                     case_name = &variant_name,
                                 ));
                             }
@@ -853,7 +829,11 @@ impl Swift {
     }
 }
 
-fn swift_keyword_aware_rename(name: Cow<str>) -> Cow<str> {
+fn swift_keyword_aware_rename<'a, T>(name: T) -> Cow<'a, str>
+where
+    T: Into<Cow<'a, str>>,
+{
+    let name = name.into();
     if SWIFT_KEYWORDS.contains(&name.as_ref()) {
         Cow::Owned(format!("`{name}`"))
     } else {

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -12,6 +12,7 @@ use itertools::{Either, Itertools};
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap},
     fs::File,
     io::{self, Write},
@@ -241,7 +242,8 @@ impl Language for Swift {
         self.write_comments(w, 0, &ty.comments)?;
 
         let swift_prefix = &self.prefix;
-        let type_name = swift_keyword_aware_rename(&format!("{}{}", swift_prefix, ty.id.renamed));
+        let type_name =
+            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", swift_prefix, ty.id.renamed)));
 
         writeln!(
             w,
@@ -264,7 +266,8 @@ impl Language for Swift {
         writeln!(w)?;
         self.write_comments(w, 0, &rs.comments)?;
 
-        let type_name = swift_keyword_aware_rename(&format!("{}{}", self.prefix, rs.id.renamed));
+        let type_name =
+            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", self.prefix, rs.id.renamed)));
 
         // If there are no decorators found for this struct, still write `Codable` and default decorators for structs
         // Check if this struct's decorators contains swift in the hashmap
@@ -307,7 +310,9 @@ impl Language for Swift {
             if f.id.renamed.chars().any(|c| c == '-') {
                 coding_keys.push(format!(
                     r##"{} = "{}""##,
-                    remove_dash_from_identifier(&swift_keyword_aware_rename(&f.id.renamed)),
+                    remove_dash_from_identifier(
+                        swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
+                    ),
                     &f.id.renamed
                 ));
 
@@ -315,9 +320,9 @@ impl Language for Swift {
                 // situation like this
                 should_write_coding_keys = true;
             } else {
-                coding_keys.push(remove_dash_from_identifier(&swift_keyword_aware_rename(
-                    &f.id.renamed,
-                )));
+                coding_keys.push(remove_dash_from_identifier(
+                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref(),
+                ));
             }
 
             let case_type: String = match f.type_override(SupportedLanguage::Swift) {
@@ -330,7 +335,9 @@ impl Language for Swift {
             writeln!(
                 w,
                 "\tpublic let {}: {}{}",
-                remove_dash_from_identifier(&swift_keyword_aware_rename(&f.id.renamed)),
+                remove_dash_from_identifier(
+                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
+                ),
                 case_type,
                 (f.has_default && !f.ty.is_optional())
                     .then_some("?")
@@ -378,7 +385,9 @@ impl Language for Swift {
                 w,
                 "\n\t\tself.{} = {}",
                 remove_dash_from_identifier(&f.id.renamed),
-                remove_dash_from_identifier(&swift_keyword_aware_rename(&f.id.renamed))
+                remove_dash_from_identifier(
+                    swift_keyword_aware_rename(Cow::Borrowed(&f.id.renamed)).as_ref()
+                )
             )?;
         }
         if !rs.fields.is_empty() {
@@ -416,7 +425,7 @@ impl Language for Swift {
 
         let shared = e.shared();
         let enum_name =
-            swift_keyword_aware_rename(&format!("{}{}", self.prefix, shared.id.renamed));
+            swift_keyword_aware_rename(Cow::Owned(format!("{}{}", self.prefix, shared.id.renamed)));
         let always_present = match e {
             RustEnum::Unit(_) => ["String"]
                 .into_iter()
@@ -551,13 +560,17 @@ impl Swift {
                     self.write_comments(w, 1, &v.shared().comments)?;
                     if v.shared().id.renamed == variant_name {
                         // We don't need to handle any renaming
-                        writeln!(w, "\tcase {}", &swift_keyword_aware_rename(&variant_name))?;
+                        writeln!(
+                            w,
+                            "\tcase {}",
+                            &swift_keyword_aware_rename(Cow::Borrowed(&variant_name))
+                        )?;
                     } else {
                         // We do need to handle renaming
                         writeln!(
                             w,
                             "\tcase {} = {:?}",
-                            swift_keyword_aware_rename(&variant_name),
+                            swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
                             &v.shared().id.renamed
                         )?;
                     }
@@ -590,16 +603,20 @@ impl Swift {
                     };
 
                     coding_keys.push(if variant_name == v.shared().id.renamed {
-                        swift_keyword_aware_rename(&variant_name)
+                        swift_keyword_aware_rename(Cow::Borrowed(&variant_name)).into_owned()
                     } else {
                         format!(
                             r##"{} = "{}""##,
-                            swift_keyword_aware_rename(&variant_name),
+                            swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
                             &v.shared().id.renamed
                         )
                     });
 
-                    write!(w, "\tcase {}", swift_keyword_aware_rename(&variant_name))?;
+                    write!(
+                        w,
+                        "\tcase {}",
+                        swift_keyword_aware_rename(Cow::Borrowed(&variant_name))
+                    )?;
 
                     match v {
                         RustEnumVariant::Unit(_) => {
@@ -616,7 +633,8 @@ impl Swift {
 		case .{case_name}:
 			try container.encode(CodingKeys.{case_name}, forKey: .{tag_key})",
                                 tag_key = tag_key,
-                                case_name = swift_keyword_aware_rename(&variant_name),
+                                case_name =
+                                    swift_keyword_aware_rename(Cow::Borrowed(&variant_name)),
                             ));
                         }
                         RustEnumVariant::Tuple { ty, .. } => {
@@ -624,7 +642,11 @@ impl Swift {
                             let case_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
                                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                            write!(w, "({})", swift_keyword_aware_rename(&case_type))?;
+                            write!(
+                                w,
+                                "({})",
+                                swift_keyword_aware_rename(Cow::Borrowed(&case_type))
+                            )?;
 
                             if content_optional {
                                 decoding_cases.push(format!(
@@ -639,7 +661,8 @@ impl Swift {
 					return
 				}}",
                                     content_key = content_key,
-                                    case_type = swift_keyword_aware_rename(&case_type),
+                                    case_type =
+                                        swift_keyword_aware_rename(Cow::Borrowed(&case_type)),
                                     case_name = &variant_name
                                 ))
                             } else {
@@ -651,7 +674,8 @@ impl Swift {
 					return
 				}}",
                                     content_key = content_key,
-                                    case_type = swift_keyword_aware_rename(&case_type),
+                                    case_type =
+                                        swift_keyword_aware_rename(Cow::Borrowed(&case_type)),
                                     case_name = &variant_name,
                                 ));
                             }
@@ -829,9 +853,10 @@ impl Swift {
     }
 }
 
-fn swift_keyword_aware_rename(name: &str) -> String {
-    if SWIFT_KEYWORDS.contains(&name) {
-        return format!("`{}`", name);
+fn swift_keyword_aware_rename(name: Cow<str>) -> Cow<str> {
+    if SWIFT_KEYWORDS.contains(&name.as_ref()) {
+        Cow::Owned(format!("`{name}`"))
+    } else {
+        name
     }
-    name.to_string()
 }

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -1,9 +1,6 @@
 use crate::{
     language::{Language, SupportedLanguage},
-    parser::{
-        remove_dash_from_identifier, ParsedData, SWIFT_DECORATOR,
-        SWIFT_GENERIC_CONSTRAINTS_DECORATOR,
-    },
+    parser::{remove_dash_from_identifier, DecoratorKind, ParsedData},
     rename::RenameExt,
     rust_types::{
         DecoratorMap, RustEnum, RustEnumVariant, RustStruct, RustTypeAlias, RustTypeFormatError,
@@ -272,11 +269,7 @@ impl Language for Swift {
 
         // let default_generic_constraints = self.default_generic_constraints.clone();
         // Check if this struct's decorators contains swift in the hashmap
-        if let Some(swift_decs) = rs
-            .decorators
-            .get(&SupportedLanguage::Swift)
-            .and_then(|d| d.get(SWIFT_DECORATOR))
-        {
+        if let Some(swift_decs) = rs.decorators.get(&DecoratorKind::Swift) {
             // For reach item in the received decorators in the typeshared struct add it to the original vector
             // this avoids duplicated of `Codable` without needing to `.sort()` then `.dedup()`
             // Note: the list received from `rs.decorators` is already deduped
@@ -404,12 +397,7 @@ impl Language for Swift {
                 .for_each(|dec| decs.push(dec));
 
             // Check if this enum's decorators contains swift in the hashmap
-            if let Some(swift_decs) = e
-                .shared()
-                .decorators
-                .get(&SupportedLanguage::Swift)
-                .and_then(|d| d.get(SWIFT_DECORATOR))
-            {
+            if let Some(swift_decs) = e.shared().decorators.get(&DecoratorKind::Swift) {
                 // Add any decorators from the typeshared enum
                 decs.extend(
                     // Note: `swift_decs` is already deduped
@@ -800,8 +788,7 @@ impl Swift {
         generic_types: &'a [String],
     ) -> String {
         let swift_generic_contraints_annotated = decorator_map
-            .get(&SupportedLanguage::Swift)
-            .and_then(|d| d.get(SWIFT_GENERIC_CONSTRAINTS_DECORATOR))
+            .get(&DecoratorKind::SwiftGenericConstraints)
             .map(|generic_constraints| {
                 generic_constraints
                     .iter()

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -780,6 +780,9 @@ impl Swift {
 
         let mut decs = self.get_default_decorators();
 
+        // Unit type can be used as generic impl constrained to Equatable.
+        decs.push("Equatable".into());
+
         // If there are no decorators found for this struct, still write `Codable` and default decorators for structs
         if !decs.contains(&CODABLE.to_string()) {
             decs.push(CODABLE.to_string());

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -701,22 +701,23 @@ fn literal_to_string(lit: &syn::Lit) -> Option<String> {
 /// Takes a slice of `syn::Attribute`, returns a `HashMap<language, Vec<decoration_words>>`, where `language` is `SupportedLanguage` and `decoration_words` is `String`
 fn get_decorators(attrs: &[syn::Attribute]) -> DecoratorMap {
     // The resulting HashMap, Key is the language, and the value is a vector of decorators words that will be put onto structures
-    let mut out: DecoratorMap = HashMap::new();
+    let mut decorator_map: DecoratorMap = HashMap::new();
 
-    let add_decorators = |name: DecoratorKind, map: &mut DecoratorMap| {
-        for value in get_name_value_meta_items(attrs, name.as_str(), TYPESHARE) {
+    for decorator_kind in [
+        DecoratorKind::Swift,
+        DecoratorKind::SwiftGenericConstraints,
+        DecoratorKind::Kotlin,
+    ] {
+        for value in get_name_value_meta_items(attrs, decorator_kind.as_str(), TYPESHARE) {
             let constraints = || value.split(',').map(|s| s.trim().to_string());
-            map.entry(name)
+            decorator_map
+                .entry(decorator_kind)
                 .and_modify(|dec_vals| dec_vals.extend(constraints()))
                 .or_insert(constraints().collect());
         }
-    };
+    }
 
-    add_decorators(DecoratorKind::Swift, &mut out);
-    add_decorators(DecoratorKind::SwiftGenericConstraints, &mut out);
-    add_decorators(DecoratorKind::Kotlin, &mut out);
-
-    out
+    decorator_map
 }
 
 fn get_tag_key(attrs: &[syn::Attribute]) -> Option<String> {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -698,9 +698,8 @@ fn literal_to_string(lit: &syn::Lit) -> Option<String> {
 }
 
 /// Checks the struct or enum for decorators like `#[typeshare(swift = "Codable, Equatable")]`
-/// Takes a slice of `syn::Attribute`, returns a `HashMap<language, Vec<decoration_words>>`, where `language` is `SupportedLanguage` and `decoration_words` is `String`
+/// Takes a slice of `syn::Attribute`, returns a [`DecoratorMap`].
 fn get_decorators(attrs: &[syn::Attribute]) -> DecoratorMap {
-    // The resulting HashMap, Key is the language, and the value is a vector of decorators words that will be put onto structures
     let mut decorator_map: DecoratorMap = HashMap::new();
 
     for decorator_kind in [

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -700,7 +700,7 @@ fn literal_to_string(lit: &syn::Lit) -> Option<String> {
 /// Checks the struct or enum for decorators like `#[typeshare(swift = "Codable, Equatable")]`
 /// Takes a slice of `syn::Attribute`, returns a [`DecoratorMap`].
 fn get_decorators(attrs: &[syn::Attribute]) -> DecoratorMap {
-    let mut decorator_map: DecoratorMap = HashMap::new();
+    let mut decorator_map: DecoratorMap = DecoratorMap::new();
 
     for decorator_kind in [
         DecoratorKind::Swift,
@@ -708,11 +708,10 @@ fn get_decorators(attrs: &[syn::Attribute]) -> DecoratorMap {
         DecoratorKind::Kotlin,
     ] {
         for value in get_name_value_meta_items(attrs, decorator_kind.as_str(), TYPESHARE) {
-            let constraints = || value.split(',').map(|s| s.trim().to_string());
             decorator_map
                 .entry(decorator_kind)
-                .and_modify(|dec_vals| dec_vals.extend(constraints()))
-                .or_insert(constraints().collect());
+                .or_default()
+                .extend(value.split(',').map(|s| s.trim().to_string()));
         }
     }
 

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -6,11 +6,11 @@ use syn::{Expr, ExprLit, Lit, TypeArray, TypeSlice};
 use thiserror::Error;
 
 use crate::language::SupportedLanguage;
-use crate::parser::DecoratorName;
+use crate::parser::DecoratorKind;
 use crate::visitors::accept_type;
 
 /// Type level typeshare attributes are mapped by target language and a mapping of attribute.
-pub type DecoratorMap = HashMap<SupportedLanguage, HashMap<DecoratorName, BTreeSet<String>>>;
+pub type DecoratorMap = HashMap<DecoratorKind, BTreeSet<String>>;
 
 /// Identifier used in Rust structs, enums, and fields. It includes the `original` name and the `renamed` value after the transformation based on `serde` attributes.
 #[derive(Debug, Clone, PartialEq)]

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -6,7 +6,11 @@ use syn::{Expr, ExprLit, Lit, TypeArray, TypeSlice};
 use thiserror::Error;
 
 use crate::language::SupportedLanguage;
+use crate::parser::DecoratorName;
 use crate::visitors::accept_type;
+
+/// Type level typeshare attributes are mapped by target language and a mapping of attribute.
+pub type DecoratorMap = HashMap<SupportedLanguage, HashMap<DecoratorName, BTreeSet<String>>>;
 
 /// Identifier used in Rust structs, enums, and fields. It includes the `original` name and the `renamed` value after the transformation based on `serde` attributes.
 #[derive(Debug, Clone, PartialEq)]
@@ -43,7 +47,7 @@ pub struct RustStruct {
     /// so we need to collect them here.
     pub comments: Vec<String>,
     /// Attributes that exist for this struct.
-    pub decorators: HashMap<SupportedLanguage, Vec<String>>,
+    pub decorators: DecoratorMap,
 }
 
 /// Rust type alias.
@@ -566,7 +570,7 @@ pub struct RustEnumShared {
     /// Decorators applied to the enum for generation in other languages
     ///
     /// Example: `#[typeshare(swift = "Equatable, Comparable, Hashable")]`.
-    pub decorators: HashMap<SupportedLanguage, Vec<String>>,
+    pub decorators: DecoratorMap,
     /// True if this enum references itself in any field of any variant
     /// Swift needs the special keyword `indirect` for this case
     pub is_recursive: bool,

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -383,6 +383,7 @@ tests! {
     can_generate_generic_struct: [
         swift {
             prefix: "Core".into(),
+            codablevoid_constraints: vec!["Equatable".into()]
         },
         kotlin,
         scala,
@@ -542,7 +543,7 @@ tests! {
     generate_types_with_keywords: [swift];
     // TODO: how is this different from generates_empty_structs_and_initializers?
     use_correct_decoded_variable_name: [swift, kotlin, scala,  typescript, go];
-    can_handle_unit_type: [swift, kotlin, scala,  typescript, go];
+    can_handle_unit_type: [swift { codablevoid_constraints: vec!["Equatable".into()]} , kotlin, scala,  typescript, go];
 
     //3 tests for adding decorators to enums and structs
     const_enum_decorator: [ swift{ prefix: "OP".to_string(), } ];
@@ -569,5 +570,5 @@ tests! {
         go
     ];
     can_generate_anonymous_struct_with_skipped_fields: [swift, kotlin, scala, typescript, go];
-    generic_struct_with_constraints_and_decorators: [swift];
+    generic_struct_with_constraints_and_decorators: [swift { codablevoid_constraints: vec!["Equatable".into()]}];
 }


### PR DESCRIPTION
This updates how generic type constraints are applied to swift types. Before if a type had a generic member we would implicitly apply the same type constraints to the generic constraints. That is not always desirable. This allows the user to define the generic type constraints via the `swiftGenericConstraints` typeshare attribute.

See example in `core/data/tests/generic_struct_with_constraints_and_decorators/input.rs`.

Also removed excessive allocations in swift.rs.

Introduced swift config option `codablevoid_constraints` which allows defining constraints for `CodableVoid`.