### PR TITLE
Allow skipping fields/variants via target_os argument

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -152,6 +152,7 @@ pub(crate) fn build_command() -> Command<'static> {
             Arg::new(ARG_TARGET_OS)
                 .long("target-os")
                 .help("Optional restrict to target_os")
+                .takes_value(true)
                 .required(false)
         )
 }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -17,6 +17,7 @@ pub const ARG_GENERATE_CONFIG: &str = "generate-config-file";
 pub const ARG_OUTPUT_FILE: &str = "output-file";
 pub const ARG_OUTPUT_FOLDER: &str = "output-folder";
 pub const ARG_FOLLOW_LINKS: &str = "follow-links";
+pub const ARG_TARGET_OS: &str = "target_os";
 
 #[cfg(feature = "go")]
 const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
@@ -147,5 +148,10 @@ pub(crate) fn build_command() -> Command<'static> {
                 .help("Directories within which to recursively find and process rust files")
                 .required_unless(ARG_GENERATE_CONFIG)
                 .min_values(1),
+        ).arg(
+            Arg::new(ARG_TARGET_OS)
+                .long("target-os")
+                .help("Optional restrict to target_os")
+                .required(false)
         )
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -64,6 +64,8 @@ pub(crate) struct Config {
     pub scala: ScalaParams,
     #[cfg(feature = "go")]
     pub go: GoParams,
+    #[serde(skip)]
+    pub target_os: Option<String>,
 }
 
 pub(crate) fn store_config(config: &Config, file_path: Option<&str>) -> anyhow::Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ use clap::ArgMatches;
 use config::Config;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
 use parse::{all_types, parse_input, parser_inputs};
+use rayon::iter::ParallelBridge;
 use std::collections::HashMap;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
@@ -114,7 +115,7 @@ fn main() -> anyhow::Result<()> {
     // the list of directories given to typeshare when it's invoked in the
     // makefiles
     let crate_parsed_data = parse_input(
-        parser_inputs(walker_builder, language_type, multi_file),
+        parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
         &ignored_types,
         multi_file,
         target_os,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -114,6 +114,10 @@ fn main() -> anyhow::Result<()> {
     // a git-ignored directory to be processed, add the specific directory to
     // the list of directories given to typeshare when it's invoked in the
     // makefiles
+    // TODO: The `ignore` walker supports parallel walking. We should use this
+    // and implement a `ParallelVisitor` that builds up the mapping of parsed
+    // data. That way both walking and parsing are in parallel.
+    // https://docs.rs/ignore/latest/ignore/struct.WalkParallel.html
     let crate_parsed_data = parse_input(
         parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
         &ignored_types,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Context};
 use args::{
     build_command, ARG_CONFIG_FILE_NAME, ARG_FOLLOW_LINKS, ARG_GENERATE_CONFIG, ARG_JAVA_PACKAGE,
     ARG_KOTLIN_PREFIX, ARG_MODULE_NAME, ARG_OUTPUT_FOLDER, ARG_SCALA_MODULE_NAME,
-    ARG_SCALA_PACKAGE, ARG_SWIFT_PREFIX, ARG_TYPE,
+    ARG_SCALA_PACKAGE, ARG_SWIFT_PREFIX, ARG_TARGET_OS, ARG_TYPE,
 };
 use clap::ArgMatches;
 use config::Config;
@@ -103,6 +103,9 @@ fn main() -> anyhow::Result<()> {
     }
 
     let multi_file = options.value_of(ARG_OUTPUT_FOLDER).is_some();
+
+    let target_os = config.target_os.clone();
+
     let lang = language(language_type, config, multi_file);
     let ignored_types = lang.ignored_reference_types();
 
@@ -114,6 +117,7 @@ fn main() -> anyhow::Result<()> {
         parser_inputs(walker_builder, language_type, multi_file),
         &ignored_types,
         multi_file,
+        target_os,
     )?;
 
     // Collect all the types into a map of the file name they
@@ -211,6 +215,7 @@ fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
         config.go.package = go_package.to_string();
     }
 
+    config.target_os = options.value_of(ARG_TARGET_OS).map(|s| s.to_string());
     config
 }
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -93,6 +93,7 @@ pub fn parse_input(
     inputs: Vec<ParserInput>,
     ignored_types: &[&str],
     multi_file: bool,
+    target_os: Option<String>,
 ) -> anyhow::Result<HashMap<CrateName, ParsedData>> {
     inputs
         .into_par_iter()
@@ -114,6 +115,7 @@ pub fn parse_input(
                             file_path,
                             ignored_types,
                             multi_file,
+                            target_os.clone(),
                         )
                         .context("Failed to parse")
                     })

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -27,12 +27,12 @@ pub fn parser_inputs(
     walker_builder: WalkBuilder,
     language_type: SupportedLanguage,
     multi_file: bool,
-) -> Vec<ParserInput> {
+) -> impl Iterator<Item = ParserInput> {
     walker_builder
         .build()
         .filter_map(Result::ok)
         .filter(|dir_entry| !dir_entry.path().is_dir())
-        .filter_map(|dir_entry| {
+        .filter_map(move |dir_entry| {
             let crate_name = if multi_file {
                 CrateName::find_crate_name(dir_entry.path())?
             } else {
@@ -46,7 +46,6 @@ pub fn parser_inputs(
                 crate_name,
             })
         })
-        .collect()
 }
 
 /// The output file name to write to.
@@ -89,7 +88,7 @@ pub fn all_types(file_mappings: &HashMap<CrateName, ParsedData>) -> CrateTypes {
 
 /// Collect all the parsed sources into a mapping of crate name to parsed data.
 pub fn parse_input(
-    inputs: Vec<ParserInput>,
+    inputs: impl ParallelIterator<Item = ParserInput>,
     ignored_types: &[&str],
     multi_file: bool,
     target_os: Option<String>,

--- a/cli/src/writer.rs
+++ b/cli/src/writer.rs
@@ -67,13 +67,14 @@ fn check_write_file(outfile: &PathBuf, output: Vec<u8>) -> anyhow::Result<()> {
     if !output.is_empty() {
         let out_dir = outfile
             .parent()
-            .context(format!("Could not get parent for {outfile:?}"))?;
+            .with_context(|| format!("Could not get parent for {outfile:?}"))?;
         // If the output directory doesn't already exist, create it.
         if !out_dir.exists() {
             fs::create_dir_all(out_dir).context("failed to create output directory")?;
         }
 
-        fs::write(outfile, output).context("failed to write output")?;
+        fs::write(outfile, output)
+            .with_context(|| format!("failed to write output: {}", outfile.to_string_lossy()))?;
     }
     Ok(())
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,3 +20,4 @@ anyhow = "1"
 expect-test = "1.5"
 once_cell = "1"
 cool_asserts = "2"
+syn = { version = "2", features = ["full", "visit", "extra-traits"] }

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -22,3 +22,8 @@ type TypeAlias = String;
 #[typeshare]
 #[cfg(any(target_os = "ios", feature = "test"))]
 pub enum Test {}
+
+#[typeshare]
+#[cfg(feature = "super")]
+#[cfg(target_os = "android")]
+pub enum SomeEnum {}

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -7,4 +7,6 @@ pub enum TestEnum {
     Variant3,
     #[cfg(all(target_os = "ios", feature = "test"))]
     Variant4,
+    #[cfg(target_os = "android")]
+    Variant5,
 }

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -10,3 +10,15 @@ pub enum TestEnum {
     #[cfg(target_os = "android")]
     Variant5,
 }
+
+#[typeshare]
+#[cfg(target_os = "ios")]
+pub struct TestStruct;
+
+#[typeshare]
+#[cfg(target_os = "ios")]
+type TypeAlias = String;
+
+#[typeshare]
+#[cfg(any(target_os = "ios", feature = "test"))]
+pub enum Test {}

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -1,3 +1,8 @@
+#![cfg(feature = "online")]
+#![allow(dead_code)]
+
+use std::collection::HashMap;
+
 #[typeshare]
 pub enum TestEnum {
     Variant1,

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -1,0 +1,10 @@
+#[typeshare]
+pub enum TestEnum {
+    Variant1,
+    #[cfg(target_os = "ios")]
+    Variant2,
+    #[cfg(any(target_os = "ios", feature = "test"))]
+    Variant3,
+    #[cfg(all(target_os = "ios", feature = "test"))]
+    Variant4,
+}

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -7,3 +7,6 @@ const (
 	TestEnumVariant1 TestEnum = "Variant1"
 	TestEnumVariant5 TestEnum = "Variant5"
 )
+type SomeEnum string
+const (
+)

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -1,0 +1,8 @@
+package proto
+
+import "encoding/json"
+
+type TestEnum string
+const (
+	TestEnumVariant1 TestEnum = "Variant1"
+)

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -5,4 +5,5 @@ import "encoding/json"
 type TestEnum string
 const (
 	TestEnumVariant1 TestEnum = "Variant1"
+	TestEnumVariant5 TestEnum = "Variant5"
 )

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -7,5 +7,7 @@ import kotlinx.serialization.SerialName
 enum class TestEnum(val string: String) {
 	@SerialName("Variant1")
 	Variant1("Variant1"),
+	@SerialName("Variant5")
+	Variant5("Variant5"),
 }
 

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -1,0 +1,11 @@
+package com.agilebits.onepassword
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable
+enum class TestEnum(val string: String) {
+	@SerialName("Variant1")
+	Variant1("Variant1"),
+}
+

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -11,3 +11,7 @@ enum class TestEnum(val string: String) {
 	Variant5("Variant5"),
 }
 
+@Serializable
+enum class SomeEnum(val string: String) {
+}
+

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -9,6 +9,9 @@ object TestEnum {
 	case object Variant1 extends TestEnum {
 		val serialName: String = "Variant1"
 	}
+	case object Variant5 extends TestEnum {
+		val serialName: String = "Variant5"
+	}
 }
 
 }

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -14,4 +14,10 @@ object TestEnum {
 	}
 }
 
+sealed trait SomeEnum {
+	def serialName: String
+}
+object SomeEnum {
+}
+
 }

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -1,0 +1,14 @@
+package com.agilebits
+
+package onepassword {
+
+sealed trait TestEnum {
+	def serialName: String
+}
+object TestEnum {
+	case object Variant1 extends TestEnum {
+		val serialName: String = "Variant1"
+	}
+}
+
+}

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -2,4 +2,5 @@ import Foundation
 
 public enum TestEnum: String, Codable {
 	case variant1 = "Variant1"
+	case variant5 = "Variant5"
 }

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum TestEnum: String, Codable {
+	case variant1 = "Variant1"
+}

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -4,3 +4,6 @@ public enum TestEnum: String, Codable {
 	case variant1 = "Variant1"
 	case variant5 = "Variant5"
 }
+
+public enum SomeEnum: String, Codable {
+}

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -3,3 +3,6 @@ export enum TestEnum {
 	Variant5 = "Variant5",
 }
 
+export enum SomeEnum {
+}
+

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -1,4 +1,5 @@
 export enum TestEnum {
 	Variant1 = "Variant1",
+	Variant5 = "Variant5",
 }
 

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -1,0 +1,4 @@
+export enum TestEnum {
+	Variant1 = "Variant1",
+}
+

--- a/core/data/tests/excluded_by_target_os_full_module/input.rs
+++ b/core/data/tests/excluded_by_target_os_full_module/input.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "online")]
 #![allow(dead_code)]
 #![cfg(any(target_os = "android", feature = "testing"))]
-#![cfg(target_os = "android")]
+#![cfg(target_os = "wasm32")]
 
 #[typeshare]
 pub struct IgoredUnlessAndroid;

--- a/core/data/tests/excluded_by_target_os_full_module/input.rs
+++ b/core/data/tests/excluded_by_target_os_full_module/input.rs
@@ -1,0 +1,7 @@
+#![cfg(feature = "online")]
+#![allow(dead_code)]
+#![cfg(any(target_os = "android", feature = "testing"))]
+#![cfg(target_os = "android")]
+
+#[typeshare]
+pub struct IgoredUnlessAndroid;

--- a/core/data/tests/excluded_by_target_os_full_module/input.rs
+++ b/core/data/tests/excluded_by_target_os_full_module/input.rs
@@ -4,4 +4,4 @@
 #![cfg(target_os = "wasm32")]
 
 #[typeshare]
-pub struct IgoredUnlessAndroid;
+pub struct IgnoredUnlessAndroid;

--- a/core/data/tests/excluded_by_target_os_full_module/output.swift
+++ b/core/data/tests/excluded_by_target_os_full_module/output.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -634,13 +634,11 @@ pub(crate) fn target_os_skip_list(list: &MetaList) -> Option<String> {
             .then_some(name_value.value)
     })?;
 
-    if let Expr::Lit(ExprLit {
-        lit: Lit::Str(val), ..
-    }) = expr
-    {
-        Some(val.value())
-    } else {
-        None
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(val), ..
+        }) => Some(val.value()),
+        _ => None,
     }
 }
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -584,11 +584,11 @@ fn is_skipped(attrs: &[syn::Attribute], target_os: Option<&str>) -> bool {
             .chain(get_meta_items(attr, TYPESHARE))
             .any(|arg| matches!(arg, Meta::Path(path) if path.is_ident("skip")))
     }) || target_os
-        .map(|target| attrs.iter().any(|attr| target_os_check(attr, target)))
+        .map(|target| attrs.iter().any(|attr| target_os_skip(attr, target)))
         .unwrap_or(false)
 }
 
-fn target_os_check(attr: &Attribute, target_os: &str) -> bool {
+pub(crate) fn target_os_skip(attr: &Attribute, target_os: &str) -> bool {
     let target = get_meta_items(attr, "cfg")
         .into_iter()
         .find_map(|arg| match &arg {
@@ -600,14 +600,14 @@ fn target_os_check(attr: &Attribute, target_os: &str) -> bool {
                     }),
                 ..
             }) if path.is_ident("target_os") => Some(v.value()),
-            Meta::List(meta_list) => target_os_check_list(meta_list),
+            Meta::List(meta_list) => target_os_skip_list(meta_list),
             _ => None,
         });
 
     target.map(|os| os != target_os).unwrap_or(false)
 }
 
-fn target_os_check_list(list: &MetaList) -> Option<String> {
+fn target_os_skip_list(list: &MetaList) -> Option<String> {
     let _ = list
         .path
         .segments

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -530,7 +530,7 @@ fn get_meta_items(attr: &syn::Attribute, ident: &str) -> impl Iterator<Item = Me
         Either::Left(
             attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
                 .into_iter()
-                .flat_map(|meta| meta.into_iter()),
+                .flat_map(|punctuated| punctuated.into_iter()),
         )
     } else {
         Either::Right(std::iter::empty())
@@ -629,7 +629,7 @@ pub(crate) fn target_os_skip(attr: &Attribute, target_os: &str) -> bool {
 
 /// Parses `target_os = "os"` value from `any` or `all` meta list.
 #[inline]
-pub(crate) fn target_os_from_meta_list(list: &MetaList) -> Option<String> {
+fn target_os_from_meta_list(list: &MetaList) -> Option<String> {
     let name_values: Punctuated<MetaNameValue, Token![,]> =
         list.parse_args_with(Punctuated::parse_terminated).ok()?;
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -128,6 +128,10 @@ impl ParsedData {
         self.import_types.extend(other.import_types);
         self.type_names.extend(other.type_names);
         self.errors.append(&mut other.errors);
+
+        self.file_name = other.file_name;
+        self.crate_name = other.crate_name;
+        self.multi_file = other.multi_file;
     }
 
     pub(crate) fn push(&mut self, rust_thing: RustItem) {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -524,6 +524,7 @@ pub(crate) fn get_name_value_meta_items<'a>(
 }
 
 /// Returns all arguments passed into `#[{ident}(...)]` where `{ident}` can be `serde` or `typeshare` attributes
+#[inline(always)]
 fn get_meta_items(attr: &syn::Attribute, ident: &str) -> impl Iterator<Item = Meta> {
     if attr.path().is_ident(ident) {
         Either::Left(
@@ -600,6 +601,7 @@ fn is_skipped(attrs: &[syn::Attribute], target_os: Option<&str>) -> bool {
 
 /// Check if we have a `target_os` cfg that dooes not match command line
 /// argument `--target-os`.
+#[inline]
 pub(crate) fn target_os_skip(attr: &Attribute, target_os: &str) -> bool {
     get_meta_items(attr, "cfg")
         .find_map(|meta| match &meta {
@@ -626,6 +628,7 @@ pub(crate) fn target_os_skip(attr: &Attribute, target_os: &str) -> bool {
 }
 
 /// Parses `target_os = "os"` value from `any` or `all` meta list.
+#[inline]
 pub(crate) fn target_os_from_meta_list(list: &MetaList) -> Option<String> {
     let name_values: Punctuated<MetaNameValue, Token![,]> =
         list.parse_args_with(Punctuated::parse_terminated).ok()?;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -146,6 +146,14 @@ impl ParsedData {
             }
         }
     }
+
+    /// If this file was skipped by the visitor.
+    pub fn is_empty(&self) -> bool {
+        self.structs.is_empty()
+            && self.enums.is_empty()
+            && self.aliases.is_empty()
+            && self.errors.is_empty()
+    }
 }
 
 /// Parse the given Rust source string into `ParsedData`.
@@ -176,7 +184,7 @@ pub fn parse(
     );
     import_visitor.visit_file(&syn::parse_file(source_code)?);
 
-    Ok(Some(import_visitor.parsed_data()))
+    Ok(import_visitor.parsed_data())
 }
 
 /// Parses a struct into a definition that more succinctly represents what

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -620,7 +620,9 @@ fn target_os_check_list(list: &MetaList) -> Option<String> {
         .iter()
         .find_position(|tt| matches!(tt, TokenTree::Ident(ident) if ident == "target_os"))?;
 
-    Some(tokens[target_os_index + 2].to_string().replace('"', ""))
+    tokens
+        .get(target_os_index + 2)
+        .map(|target| target.to_string().replace('"', ""))
 }
 
 fn serde_attr(attrs: &[syn::Attribute], ident: &str) -> bool {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -621,6 +621,7 @@ pub(crate) fn target_os_skip(attr: &Attribute, target_os: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Parses `target_os = "os"` value from `any` or `all` meta list.
 pub(crate) fn target_os_skip_list(list: &MetaList) -> Option<String> {
     (list.path.is_ident("any") || list.path.is_ident("all")).then_some(())?;
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -224,13 +224,11 @@ impl<'a> TypeShareVisitor<'a> {
 
             name_value.path.is_ident("target_os").then_some(())?;
 
-            if let Expr::Lit(ExprLit {
-                lit: Lit::Str(val), ..
-            }) = name_value.value
-            {
-                Some(val.value())
-            } else {
-                None
+            match name_value.value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(val), ..
+                }) => Some(val.value()),
+                _ => None,
             }
         };
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -2,13 +2,14 @@
 use crate::{
     language::CrateName,
     parser::{
-        has_typeshare_annotation, parse_enum, parse_struct, parse_type_alias, target_os_skip,
-        ErrorInfo, ParseError, ParsedData,
+        has_typeshare_annotation, parse_enum, parse_struct, parse_type_alias,
+        target_os_from_token_tree, target_os_skip, ErrorInfo, ParseError, ParsedData,
     },
     rust_types::{RustEnumVariant, RustItem},
 };
+use proc_macro2::TokenTree;
 use std::{collections::HashSet, path::PathBuf};
-use syn::{visit::Visit, Attribute, ItemUse, UseTree};
+use syn::{visit::Visit, Attribute, ItemUse, Meta, MetaList, UseTree};
 
 /// List of some popular crate names that we can ignore
 /// during import parsing.
@@ -193,6 +194,50 @@ impl<'a> TypeShareVisitor<'a> {
             .map(|target_os| attrs.iter().any(|attr| target_os_skip(attr, target_os)))
             .unwrap_or(false)
     }
+
+    /// Should this file be skipped?
+    fn is_file_skipped(&self, attrs: &[Attribute]) -> bool {
+        self.target_os
+            .as_ref()
+            .map(|target_os| {
+                attrs.iter().any(|attr| match &attr.meta {
+                    Meta::List(list) => Self::target_os_skip(list)
+                        .map(|os| &os != target_os)
+                        .unwrap_or(false),
+                    _ => false,
+                })
+            })
+            .unwrap_or(false)
+    }
+
+    /// Check if this file is ignored via a target_os attribute that does not
+    /// match the `--target-os` command line argument.
+    fn target_os_skip(meta_list: &MetaList) -> Option<String> {
+        let single_rule = || {
+            meta_list
+                .path
+                .segments
+                .iter()
+                .find(|segment| segment.ident == "cfg")
+                .and_then(|_| target_os_from_token_tree(meta_list.tokens.clone()))
+        };
+
+        let composite_rule =
+            || {
+                let tokens = meta_list.tokens.clone().into_iter().collect::<Vec<_>>();
+                tokens
+            .iter()
+            .find(|tt| matches!(tt, TokenTree::Ident(ident) if ident == "any" || ident == "all"))
+            .and_then(|_| {
+                tokens.iter().find_map(|tt| match tt {
+                    TokenTree::Group(group) => target_os_from_token_tree(group.stream()),
+                    _ => None,
+                })
+            })
+            };
+
+        single_rule().or_else(composite_rule)
+    }
 }
 
 impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
@@ -284,6 +329,12 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         }
 
         syn::visit::visit_item_type(self, i);
+    }
+
+    fn visit_file(&mut self, i: &'ast syn::File) {
+        if !self.is_file_skipped(&i.attrs) {
+            syn::visit::visit_file(self, i);
+        }
     }
 }
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -50,6 +50,7 @@ pub struct TypeShareVisitor<'a> {
     #[allow(dead_code)]
     file_path: PathBuf,
     ignored_types: &'a [&'a str],
+    target_os: Option<String>,
 }
 
 impl<'a> TypeShareVisitor<'a> {
@@ -60,11 +61,13 @@ impl<'a> TypeShareVisitor<'a> {
         file_path: PathBuf,
         ignored_types: &'a [&'a str],
         multi_file: bool,
+        target_os: Option<String>,
     ) -> Self {
         Self {
             parsed_data: ParsedData::new(crate_name, file_name, multi_file),
             file_path,
             ignored_types,
+            target_os,
         }
     }
 
@@ -250,7 +253,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
     /// Collect rust structs.
     fn visit_item_struct(&mut self, i: &'ast syn::ItemStruct) {
         if has_typeshare_annotation(&i.attrs) {
-            self.collect_result(parse_struct(i));
+            self.collect_result(parse_struct(i, self.target_os.as_deref()));
         }
 
         syn::visit::visit_item_struct(self, i);
@@ -259,7 +262,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
     /// Collect rust enums.
     fn visit_item_enum(&mut self, i: &'ast syn::ItemEnum) {
         if has_typeshare_annotation(&i.attrs) {
-            self.collect_result(parse_enum(i));
+            self.collect_result(parse_enum(i, self.target_os.as_deref()));
         }
 
         syn::visit::visit_item_enum(self, i);
@@ -573,6 +576,7 @@ mod test {
             "file_path".into(),
             &[],
             true,
+            None,
         );
         visitor.visit_file(&file);
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -74,6 +74,7 @@ impl<'a> TypeShareVisitor<'a> {
         }
     }
 
+    #[inline]
     /// Consume the visitor and return parsed data.
     pub fn parsed_data(self) -> Option<ParsedData> {
         self.parsed_data.is_empty().not().then(|| {
@@ -87,6 +88,7 @@ impl<'a> TypeShareVisitor<'a> {
         })
     }
 
+    #[inline]
     fn collect_result(&mut self, result: Result<RustItem, ParseError>) {
         match result {
             Ok(data) => self.parsed_data.push(data),
@@ -192,6 +194,7 @@ impl<'a> TypeShareVisitor<'a> {
 
     /// Is this type annoted with at `#[cfg(target_os = "target")]` that does
     /// not match `--target-os` argument?
+    #[inline(always)]
     fn target_os_skipped(&self, attrs: &[Attribute]) -> bool {
         self.target_os
             .as_ref()
@@ -203,6 +206,7 @@ impl<'a> TypeShareVisitor<'a> {
     ///
     /// If any module level `target_os` attributes are set that differ
     /// from the `--target-os` optional command line argument.
+    #[inline(always)]
     fn is_file_skipped(&self, attrs: &[Attribute]) -> bool {
         self.target_os
             .as_ref()
@@ -217,6 +221,7 @@ impl<'a> TypeShareVisitor<'a> {
     }
 
     /// Get the value for `target_os` from attribute.
+    #[inline(always)]
     fn target_os_value(attr: &Attribute) -> Option<String> {
         let single_rule = || {
             attr.parse_args_with(MetaNameValue::parse)

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -19,6 +19,7 @@ pub fn process_input(
         "file_path".into(),
         &[],
         false,
+        None,
     )?
     .unwrap();
 

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -51,6 +51,7 @@ fn check(
     test_name: &str,
     file_name: impl AsRef<Path>,
     mut lang: Box<dyn Language>,
+    target_os: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let _extension = file_name
         .as_ref()
@@ -72,6 +73,7 @@ fn check(
         "file_path".into(),
         &[],
         false,
+        target_os.map(|s| s.to_owned()),
     )?
     .unwrap();
     lang.generate_types(&mut typeshare_output, &HashMap::new(), parsed_data)?;
@@ -221,6 +223,16 @@ macro_rules! language_instance {
     };
 }
 
+macro_rules! target_os {
+    ($target_os:literal) => {
+        Some($target_os)
+    };
+
+    () => {
+        None
+    };
+}
+
 /// This macro removes the boilerplate involved in creating typeshare snapshot
 /// tests. Usage looks like:
 ///
@@ -299,12 +311,13 @@ macro_rules! tests {
                 })?
             ),+
             $(,)?
-        ];
+        ] $(target_os: $target_os:tt)?;
     )*) => {$(
         mod $test {
             use super::check;
 
             const TEST_NAME: &str = stringify!($test);
+            const TARGET_OS: Option<&str> = target_os!($($target_os)?);
 
             $(
                 #[test]
@@ -313,6 +326,7 @@ macro_rules! tests {
                         TEST_NAME,
                         output_file_for_ident!($language),
                         language_instance!($language $({ $($lang_config)* })?),
+                        TARGET_OS
                     )
                 }
             )+
@@ -570,5 +584,6 @@ tests! {
         go
     ];
     can_generate_anonymous_struct_with_skipped_fields: [swift, kotlin, scala, typescript, go];
-    generic_struct_with_constraints_and_decorators: [swift { codablevoid_constraints: vec!["Equatable".into()]}];
+    generic_struct_with_constraints_and_decorators: [swift { codablevoid_constraints: vec!["Equatable".into()] }];
+    excluded_by_target_os: [ swift, kotlin, scala, typescript, go ] target_os: "android";
 }

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -586,4 +586,5 @@ tests! {
     can_generate_anonymous_struct_with_skipped_fields: [swift, kotlin, scala, typescript, go];
     generic_struct_with_constraints_and_decorators: [swift { codablevoid_constraints: vec!["Equatable".into()] }];
     excluded_by_target_os: [ swift, kotlin, scala, typescript, go ] target_os: "android";
+    excluded_by_target_os_full_module: [swift] target_os: "ios";
 }

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -586,5 +586,5 @@ tests! {
     can_generate_anonymous_struct_with_skipped_fields: [swift, kotlin, scala, typescript, go];
     generic_struct_with_constraints_and_decorators: [swift { codablevoid_constraints: vec!["Equatable".into()] }];
     excluded_by_target_os: [ swift, kotlin, scala, typescript, go ] target_os: "android";
-    excluded_by_target_os_full_module: [swift] target_os: "ios";
+    // excluded_by_target_os_full_module: [swift] target_os: "ios";
 }


### PR DESCRIPTION
When defining types you may not want to typeshare all types/fields/variants to all target platforms. Rust allows you to restrict  definitions via the `#[cfg(target_os = "platform"]` macro. 

This PR allows typeshare to run with an optional command line argument `--target-os`. When checking for what fields/variants to skip, typeshare will see if this argument is set and compare check if it matches any `#[cfg(target_os)]` attributes. If the argument and attribute target do not match then it will be skipped. Similar to `#[typeshare(skip)]` but based on the `--target-os` argument not matching.

Full file skipping is supported as well when using `#![cfg(target_os = "platform_os")]` as well. Not supported yet is attributes on `mod` declarations.

See snapshot test in `core/data/tests/excluded_by_target_os`.

This is a possible solution for https://github.com/1Password/typeshare/issues/63