### PR TITLE
chore: update changelogs and bump versions for v1.10.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version 1.10.0-beta
 
+## 1.10.0-beta.6
+
+- Added support for skipping fields/variants via the `target_os` argument [#176](https://github.com/1Password/typeshare/pull/176)
+
 ## 1.10.0-beta.5
 
 - Added support for Swift generic constraints via `#[typeshare(swiftGenericConstraints)]` [#174](https://github.com/1Password/typeshare/pull/174)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.10.0-beta.5"
+version = "1.10.0-beta.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.10.0-beta.5"
+version = "1.10.0-beta.6"
 dependencies = [
  "anyhow",
  "cool_asserts",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.10.0-beta.5"
+version = "1.10.0-beta.6"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"
 license = "MIT OR Apache-2.0"
@@ -22,5 +22,5 @@ once_cell = "1"
 rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-typeshare-core = { path = "../core", version = "1.10.0-beta.5" }
+typeshare-core = { path = "../core", version = "1.10.0-beta.6" }
 anyhow = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-core"
-version = "1.10.0-beta.5"
+version = "1.10.0-beta.6"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "The code generator used by Typeshare's command line tool"


### PR DESCRIPTION
This PR prepares for a `beta.6` release including some new functionality.