### PR TITLE
Add support for Kotlin inline value classes

### DIFF
--- a/core/data/tests/struct_decorator/input.rs
+++ b/core/data/tests/struct_decorator/input.rs
@@ -15,7 +15,7 @@ pub struct BestHockeyTeams2 {
     Lies: String,
 }
 
-#[typeshare(kotlin = "Redacted")]
+#[typeshare(redacted)]
 pub struct BestHockeyTeams3 {
     PittsburghPenguins: u32,
     Lies: String,
@@ -27,5 +27,5 @@ pub struct BestHockeyTeams4 {
     Lies: String,
 }
 
-#[typeshare(kotlin = "JvmInline, Redacted")]
+#[typeshare(kotlin = "JvmInline", redacted)]
 pub struct BestHockeyTeams5(String);

--- a/core/data/tests/struct_decorator/input.rs
+++ b/core/data/tests/struct_decorator/input.rs
@@ -15,7 +15,7 @@ pub struct BestHockeyTeams2 {
     Lies: String,
 }
 
-#[typeshare(kotlin = "redacted_to_string")]
+#[typeshare(kotlin = "Redacted")]
 pub struct BestHockeyTeams3 {
     PittsburghPenguins: u32,
     Lies: String,
@@ -26,3 +26,6 @@ pub struct BestHockeyTeams4 {
     PittsburghPenguins: u32,
     Lies: String,
 }
+
+#[typeshare(kotlin = "JvmInline, Redacted")]
+pub struct BestHockeyTeams5(String);

--- a/core/data/tests/struct_decorator/output.kt
+++ b/core/data/tests/struct_decorator/output.kt
@@ -4,6 +4,14 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
+@JvmInline
+value class BestHockeyTeams5(
+	val value: String
+) {
+	override fun toString(): String = "***"
+}
+
+@Serializable
 data class BestHockeyTeams (
 	val PittsburghPenguins: UInt,
 	val Lies: String

--- a/core/data/tests/struct_decorator/output.swift
+++ b/core/data/tests/struct_decorator/output.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+public typealias OPBestHockeyTeams5 = String
+
 public struct OPBestHockeyTeams: Codable {
 	public let PittsburghPenguins: UInt32
 	public let Lies: String

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -4,14 +4,15 @@ use crate::parser::{remove_dash_from_identifier, DecoratorKind, ParsedData};
 use crate::rust_types::{RustTypeFormatError, SpecialRustType};
 use crate::{
     rename::RenameExt,
-    rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
+    rust_types::{Id, RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
 };
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
-use std::{collections::HashMap, io::Write};
+use std::{collections::BTreeSet, collections::HashMap, io::Write};
 
-const REDACTED_TO_STRING: &str = "redacted_to_string";
+const INLINE: &str = "JvmInline";
+const REDACTED: &str = "Redacted";
 
 /// All information needed for Kotlin type-code
 #[derive(Default)]
@@ -119,16 +120,50 @@ impl Language for Kotlin {
         self.write_comments(w, 0, &ty.comments)?;
         let type_name = format!("{}{}", &self.prefix, ty.id.original);
 
-        writeln!(
-            w,
-            "typealias {}{} = {}\n",
-            type_name,
-            (!ty.generic_types.is_empty())
-                .then(|| format!("<{}>", ty.generic_types.join(", ")))
-                .unwrap_or_default(),
-            self.format_type(&ty.r#type, ty.generic_types.as_slice())
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
-        )?;
+        if self.is_inline(&ty.decorators) {
+            writeln!(w, "@Serializable")?;
+            writeln!(w, "@JvmInline")?;
+            writeln!(w, "value class {}{}(", self.prefix, ty.id.renamed)?;
+
+            self.write_element(
+                w,
+                &RustField {
+                    id: Id {
+                        original: String::from("value"),
+                        renamed: String::from("value"),
+                    },
+                    ty: ty.r#type.clone(),
+                    comments: vec![],
+                    has_default: false,
+                    decorators: HashMap::new(),
+                },
+                &[],
+                false,
+            )?;
+
+            writeln!(w)?;
+
+            if self.is_redacted(&ty.decorators) {
+                writeln!(w, ") {{")?;
+                writeln!(w, "\toverride fun toString(): String = \"***\"")?;
+                writeln!(w, "}}")?;
+            } else {
+                writeln!(w, ")")?;
+            }
+
+            writeln!(w)?;
+        } else {
+            writeln!(
+                w,
+                "typealias {}{} = {}\n",
+                type_name,
+                (!ty.generic_types.is_empty())
+                    .then(|| format!("<{}>", ty.generic_types.join(", ")))
+                    .unwrap_or_default(),
+                self.format_type(&ty.r#type, ty.generic_types.as_slice())
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+            )?;
+        }
 
         Ok(())
     }
@@ -168,16 +203,16 @@ impl Language for Kotlin {
                 self.write_element(w, last, rs.generic_types.as_slice(), requires_serial_name)?;
                 writeln!(w)?;
             }
-            write!(w, ")")?;
-            if let Some(kotlin_decorators) = rs.decorators.get(&DecoratorKind::Kotlin) {
-                let redacted_decorator = String::from(REDACTED_TO_STRING);
-                if kotlin_decorators.iter().any(|d| *d == redacted_decorator) {
-                    writeln!(w, " {{")?;
-                    writeln!(w, "\toverride fun toString(): String = {:?}", rs.id.renamed)?;
-                    write!(w, "}}")?;
-                }
+
+            if self.is_redacted(&rs.decorators) {
+                writeln!(w, ") {{")?;
+                writeln!(w, "\toverride fun toString(): String = {:?}", rs.id.renamed)?;
+                writeln!(w, "}}")?;
+            } else {
+                writeln!(w, ")")?;
             }
-            writeln!(w, "\n")?;
+
+            writeln!(w)?;
         }
         Ok(())
     }
@@ -411,5 +446,19 @@ impl Kotlin {
         comments
             .iter()
             .try_for_each(|comment| self.write_comment(w, indent, comment))
+    }
+
+    fn is_redacted(&self, decorators: &HashMap<DecoratorKind, BTreeSet<String>>) -> bool {
+        match decorators.get(&DecoratorKind::Kotlin) {
+            Some(kotlin_decorators) => kotlin_decorators.iter().contains(&String::from(REDACTED)),
+            _ => false,
+        }
+    }
+
+    fn is_inline(&self, decorators: &HashMap<DecoratorKind, BTreeSet<String>>) -> bool {
+        match decorators.get(&DecoratorKind::Kotlin) {
+            Some(kotlin_decorators) => kotlin_decorators.iter().contains(&String::from(INLINE)),
+            _ => false,
+        }
     }
 }

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -12,7 +12,6 @@ use lazy_format::lazy_format;
 use std::{collections::BTreeSet, collections::HashMap, io::Write};
 
 const INLINE: &str = "JvmInline";
-const REDACTED: &str = "Redacted";
 
 /// All information needed for Kotlin type-code
 #[derive(Default)]
@@ -143,7 +142,7 @@ impl Language for Kotlin {
 
             writeln!(w)?;
 
-            if self.is_redacted(&ty.decorators) {
+            if ty.is_redacted {
                 writeln!(w, ") {{")?;
                 writeln!(w, "\toverride fun toString(): String = \"***\"")?;
                 writeln!(w, "}}")?;
@@ -204,7 +203,7 @@ impl Language for Kotlin {
                 writeln!(w)?;
             }
 
-            if self.is_redacted(&rs.decorators) {
+            if rs.is_redacted {
                 writeln!(w, ") {{")?;
                 writeln!(w, "\toverride fun toString(): String = {:?}", rs.id.renamed)?;
                 writeln!(w, "}}")?;
@@ -446,13 +445,6 @@ impl Kotlin {
         comments
             .iter()
             .try_for_each(|comment| self.write_comment(w, indent, comment))
-    }
-
-    fn is_redacted(&self, decorators: &HashMap<DecoratorKind, BTreeSet<String>>) -> bool {
-        match decorators.get(&DecoratorKind::Kotlin) {
-            Some(kotlin_decorators) => kotlin_decorators.iter().contains(&String::from(REDACTED)),
-            _ => false,
-        }
     }
 
     fn is_inline(&self, decorators: &HashMap<DecoratorKind, BTreeSet<String>>) -> bool {

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -387,6 +387,7 @@ pub trait Language {
                         &e.shared().id.original,
                     )],
                     decorators: e.shared().decorators.clone(),
+                    is_redacted: e.shared().is_redacted,
                 },
             )?;
         }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -221,6 +221,7 @@ pub(crate) fn parse_struct(
             r#type: ty.parse()?,
             comments: parse_comment_attrs(&s.attrs),
             generic_types,
+            decorators: get_decorators(&s.attrs),
         }));
     }
 
@@ -281,6 +282,7 @@ pub(crate) fn parse_struct(
                 r#type: ty,
                 comments: parse_comment_attrs(&s.attrs),
                 generic_types,
+                decorators: get_decorators(&s.attrs),
             })
         }
         // Unit structs or `None`
@@ -320,6 +322,7 @@ pub(crate) fn parse_enum(e: &ItemEnum, target_os: Option<&str>) -> Result<RustIt
             r#type: ty.parse()?,
             comments: parse_comment_attrs(&e.attrs),
             generic_types,
+            decorators: get_decorators(&e.attrs),
         }));
     }
 
@@ -481,6 +484,7 @@ pub(crate) fn parse_type_alias(t: &ItemType) -> Result<RustItem, ParseError> {
         r#type: ty,
         comments: parse_comment_attrs(&t.attrs),
         generic_types,
+        decorators: get_decorators(&t.attrs),
     }))
 }
 

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -48,6 +48,8 @@ pub struct RustStruct {
     pub comments: Vec<String>,
     /// Attributes that exist for this struct.
     pub decorators: DecoratorMap,
+    /// True if this struct contains data that needs to be redacted
+    pub is_redacted: bool,
 }
 
 /// Rust type alias.
@@ -66,6 +68,8 @@ pub struct RustTypeAlias {
     pub comments: Vec<String>,
     /// Attributes that exist for this struct.
     pub decorators: DecoratorMap,
+    /// True if this type alias contains data that needs to be redacted
+    pub is_redacted: bool,
 }
 
 /// Rust field definition.
@@ -576,6 +580,8 @@ pub struct RustEnumShared {
     /// True if this enum references itself in any field of any variant
     /// Swift needs the special keyword `indirect` for this case
     pub is_recursive: bool,
+    /// True if this enum contains data that needs to be redacted
+    pub is_redacted: bool,
 }
 
 /// Parsed information about a Rust enum variant

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -64,6 +64,8 @@ pub struct RustTypeAlias {
     pub r#type: RustType,
     /// Comments that were in the type alias source.
     pub comments: Vec<String>,
+    /// Attributes that exist for this struct.
+    pub decorators: DecoratorMap,
 }
 
 /// Rust field definition.


### PR DESCRIPTION
There are instances where we are using a type alias in Kotlin when we should be using an [inline value class](https://kotlinlang.org/docs/inline-classes.html). This pull request adds a Kotlin-specific typeshare decorator for generating these inline value classes. Additionally, updated the `redacted_to_string` decorator to `Redacted` so there is a consistent naming convention for the language-specific decorators.