### PR TITLE
Capitalize all variant names when configuration specifies so in Go

### DIFF
--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -278,6 +278,7 @@ impl Go {
                     ));
 
                     if let Some(variant_type) = variant_type {
+                        let variant_type = self.acronyms_to_uppercase(&variant_type);
                         let (variant_pointer, variant_deref, variant_ref) =
                             match (v, custom_structs.contains(&variant_type.as_str())) {
                                 (RustEnumVariant::AnonymousStruct { .. }, ..) | (.., true) => {


### PR DESCRIPTION
Before this MR, when generating Go types with algebraic enums and specifying uppercase acronyms, this would happen:
```
func (i ItemFieldDetails) OTP() *OtpFieldDetails {
	res, _ := i.content.(*OtpFieldDetails)
	return res
}

// Additional attributes for OTP fields.
type OTPFieldDetails struct {
	// The OTP code, if successfully computed
	Code *string `json:"code,omitempty"`
	// The error message, if the OTP code could not be computed
	ErrorMessage *string `json:"error_message,omitempty"`
}
```

The uppercasing was not enforced consistently, causing the Go types to error because of their different capitalization: `OTPFieldDetails` vs `OtpFieldDetails`. 

This MR fixes this.