### PR TITLE
keep the file output deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
  "clap",
  "clap_complete_command",
  "ignore",
+ "indexmap 2.2.6",
  "once_cell",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,6 @@ dependencies = [
  "clap",
  "clap_complete_command",
  "ignore",
- "indexmap 2.2.6",
  "once_cell",
  "rayon",
  "serde",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 typeshare-core = { path = "../core", version = "1.10.0-beta.6" }
 anyhow = "1"
+indexmap = "2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,4 +24,3 @@ serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 typeshare-core = { path = "../core", version = "1.10.0-beta.6" }
 anyhow = "1"
-indexmap = "2"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,10 +10,9 @@ use args::{
 use clap::ArgMatches;
 use config::Config;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
-use indexmap::IndexMap;
 use parse::{all_types, parse_input, parser_inputs};
 use rayon::iter::ParallelBridge;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
@@ -226,7 +225,7 @@ fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
 }
 
 /// Prints out all parsing errors if any and returns Err.
-fn check_parse_errors(parsed_crates: &IndexMap<CrateName, ParsedData>) -> anyhow::Result<()> {
+fn check_parse_errors(parsed_crates: &BTreeMap<CrateName, ParsedData>) -> anyhow::Result<()> {
     let mut errors_encountered = false;
     for data in parsed_crates
         .values()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@ use args::{
 use clap::ArgMatches;
 use config::Config;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
+use indexmap::IndexMap;
 use parse::{all_types, parse_input, parser_inputs};
 use rayon::iter::ParallelBridge;
 use std::collections::HashMap;
@@ -225,7 +226,7 @@ fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
 }
 
 /// Prints out all parsing errors if any and returns Err.
-fn check_parse_errors(parsed_crates: &HashMap<CrateName, ParsedData>) -> anyhow::Result<()> {
+fn check_parse_errors(parsed_crates: &IndexMap<CrateName, ParsedData>) -> anyhow::Result<()> {
     let mut errors_encountered = false;
     for data in parsed_crates
         .values()

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -1,6 +1,7 @@
 //! Source file parsing.
 use anyhow::Context;
 use ignore::WalkBuilder;
+use indexmap::IndexMap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -66,7 +67,7 @@ fn output_file_name(language_type: SupportedLanguage, crate_name: &CrateName) ->
 
 /// Collect all the typeshared types into a mapping of crate names to typeshared types. This
 /// mapping is used to lookup and generated import statements for generated files.
-pub fn all_types(file_mappings: &HashMap<CrateName, ParsedData>) -> CrateTypes {
+pub fn all_types(file_mappings: &IndexMap<CrateName, ParsedData>) -> CrateTypes {
     file_mappings
         .iter()
         .map(|(crate_name, parsed_data)| (crate_name, parsed_data.type_names.clone()))
@@ -92,12 +93,12 @@ pub fn parse_input(
     ignored_types: &[&str],
     multi_file: bool,
     target_os: Option<String>,
-) -> anyhow::Result<HashMap<CrateName, ParsedData>> {
+) -> anyhow::Result<IndexMap<CrateName, ParsedData>> {
     inputs
         .into_par_iter()
         .try_fold(
-            HashMap::new,
-            |mut parsed_crates: HashMap<CrateName, ParsedData>,
+            IndexMap::new,
+            |mut parsed_crates: IndexMap<CrateName, ParsedData>,
              ParserInput {
                  file_path,
                  file_name,
@@ -125,7 +126,7 @@ pub fn parse_input(
                 Ok(parsed_crates)
             },
         )
-        .try_reduce(HashMap::new, |mut file_maps, parsed_crates| {
+        .try_reduce(IndexMap::new, |mut file_maps, parsed_crates| {
             for (crate_name, parsed_data) in parsed_crates {
                 file_maps.entry(crate_name).or_default().add(parsed_data);
             }

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -1,10 +1,9 @@
 //! Source file parsing.
 use anyhow::Context;
 use ignore::WalkBuilder;
-use indexmap::IndexMap;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, BTreeMap, HashMap},
     path::PathBuf,
 };
 use typeshare_core::{
@@ -67,7 +66,7 @@ fn output_file_name(language_type: SupportedLanguage, crate_name: &CrateName) ->
 
 /// Collect all the typeshared types into a mapping of crate names to typeshared types. This
 /// mapping is used to lookup and generated import statements for generated files.
-pub fn all_types(file_mappings: &IndexMap<CrateName, ParsedData>) -> CrateTypes {
+pub fn all_types(file_mappings: &BTreeMap<CrateName, ParsedData>) -> CrateTypes {
     file_mappings
         .iter()
         .map(|(crate_name, parsed_data)| (crate_name, parsed_data.type_names.clone()))
@@ -93,12 +92,12 @@ pub fn parse_input(
     ignored_types: &[&str],
     multi_file: bool,
     target_os: Option<String>,
-) -> anyhow::Result<IndexMap<CrateName, ParsedData>> {
+) -> anyhow::Result<BTreeMap<CrateName, ParsedData>> {
     inputs
         .into_par_iter()
         .try_fold(
-            IndexMap::new,
-            |mut parsed_crates: IndexMap<CrateName, ParsedData>,
+            BTreeMap::new,
+            |mut parsed_crates: BTreeMap<CrateName, ParsedData>,
              ParserInput {
                  file_path,
                  file_name,
@@ -126,7 +125,7 @@ pub fn parse_input(
                 Ok(parsed_crates)
             },
         )
-        .try_reduce(IndexMap::new, |mut file_maps, parsed_crates| {
+        .try_reduce(BTreeMap::new, |mut file_maps, parsed_crates| {
             for (crate_name, parsed_data) in parsed_crates {
                 file_maps.entry(crate_name).or_default().add(parsed_data);
             }

--- a/cli/src/writer.rs
+++ b/cli/src/writer.rs
@@ -2,6 +2,7 @@
 use crate::args::{ARG_OUTPUT_FILE, ARG_OUTPUT_FOLDER};
 use anyhow::Context;
 use clap::ArgMatches;
+use indexmap::IndexMap;
 use std::{
     collections::HashMap,
     fs,
@@ -16,7 +17,7 @@ use typeshare_core::{
 pub fn write_generated(
     options: ArgMatches,
     lang: Box<dyn Language>,
-    crate_parsed_data: HashMap<CrateName, ParsedData>,
+    crate_parsed_data: IndexMap<CrateName, ParsedData>,
     import_candidates: CrateTypes,
 ) -> Result<(), anyhow::Error> {
     let output_folder = options.value_of(ARG_OUTPUT_FOLDER);
@@ -35,7 +36,7 @@ pub fn write_generated(
 fn write_multiple_files(
     mut lang: Box<dyn Language>,
     output_folder: &str,
-    crate_parsed_data: HashMap<CrateName, ParsedData>,
+    crate_parsed_data: IndexMap<CrateName, ParsedData>,
     import_candidates: CrateTypes,
 ) -> Result<(), anyhow::Error> {
     for (_crate_name, parsed_data) in crate_parsed_data {
@@ -83,10 +84,10 @@ fn check_write_file(outfile: &PathBuf, output: Vec<u8>) -> anyhow::Result<()> {
 fn write_single_file(
     mut lang: Box<dyn Language>,
     file_name: &str,
-    mut crate_parsed_data: HashMap<CrateName, ParsedData>,
+    mut crate_parsed_data: IndexMap<CrateName, ParsedData>,
 ) -> Result<(), anyhow::Error> {
     let parsed_data = crate_parsed_data
-        .remove(&SINGLE_FILE_CRATE_NAME)
+        .shift_remove(&SINGLE_FILE_CRATE_NAME)
         .context("Could not get parsed data for single file output")?;
 
     let mut output = Vec::new();

--- a/cli/src/writer.rs
+++ b/cli/src/writer.rs
@@ -2,9 +2,8 @@
 use crate::args::{ARG_OUTPUT_FILE, ARG_OUTPUT_FOLDER};
 use anyhow::Context;
 use clap::ArgMatches;
-use indexmap::IndexMap;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs,
     path::{Path, PathBuf},
 };
@@ -17,7 +16,7 @@ use typeshare_core::{
 pub fn write_generated(
     options: ArgMatches,
     lang: Box<dyn Language>,
-    crate_parsed_data: IndexMap<CrateName, ParsedData>,
+    crate_parsed_data: BTreeMap<CrateName, ParsedData>,
     import_candidates: CrateTypes,
 ) -> Result<(), anyhow::Error> {
     let output_folder = options.value_of(ARG_OUTPUT_FOLDER);
@@ -36,7 +35,7 @@ pub fn write_generated(
 fn write_multiple_files(
     mut lang: Box<dyn Language>,
     output_folder: &str,
-    crate_parsed_data: IndexMap<CrateName, ParsedData>,
+    crate_parsed_data: BTreeMap<CrateName, ParsedData>,
     import_candidates: CrateTypes,
 ) -> Result<(), anyhow::Error> {
     for (_crate_name, parsed_data) in crate_parsed_data {
@@ -84,10 +83,10 @@ fn check_write_file(outfile: &PathBuf, output: Vec<u8>) -> anyhow::Result<()> {
 fn write_single_file(
     mut lang: Box<dyn Language>,
     file_name: &str,
-    mut crate_parsed_data: IndexMap<CrateName, ParsedData>,
+    mut crate_parsed_data: BTreeMap<CrateName, ParsedData>,
 ) -> Result<(), anyhow::Error> {
     let parsed_data = crate_parsed_data
-        .shift_remove(&SINGLE_FILE_CRATE_NAME)
+        .remove(&SINGLE_FILE_CRATE_NAME)
         .context("Could not get parsed data for single file output")?;
 
     let mut output = Vec::new();

--- a/core/data/tests/can_recognize_types_inside_modules/output.go
+++ b/core/data/tests/can_recognize_types_inside_modules/output.go
@@ -5,10 +5,10 @@ import "encoding/json"
 type A struct {
 	Field uint32 `json:"field"`
 }
-type ABC struct {
+type AB struct {
 	Field uint32 `json:"field"`
 }
-type AB struct {
+type ABC struct {
 	Field uint32 `json:"field"`
 }
 type OutsideOfModules struct {

--- a/core/data/tests/can_recognize_types_inside_modules/output.kt
+++ b/core/data/tests/can_recognize_types_inside_modules/output.kt
@@ -9,12 +9,12 @@ data class A (
 )
 
 @Serializable
-data class ABC (
+data class AB (
 	val field: UInt
 )
 
 @Serializable
-data class AB (
+data class ABC (
 	val field: UInt
 )
 

--- a/core/data/tests/can_recognize_types_inside_modules/output.scala
+++ b/core/data/tests/can_recognize_types_inside_modules/output.scala
@@ -14,11 +14,11 @@ case class A (
 	field: UInt
 )
 
-case class ABC (
+case class AB (
 	field: UInt
 )
 
-case class AB (
+case class ABC (
 	field: UInt
 )
 

--- a/core/data/tests/can_recognize_types_inside_modules/output.swift
+++ b/core/data/tests/can_recognize_types_inside_modules/output.swift
@@ -8,7 +8,7 @@ public struct A: Codable {
 	}
 }
 
-public struct ABC: Codable {
+public struct AB: Codable {
 	public let field: UInt32
 
 	public init(field: UInt32) {
@@ -16,7 +16,7 @@ public struct ABC: Codable {
 	}
 }
 
-public struct AB: Codable {
+public struct ABC: Codable {
 	public let field: UInt32
 
 	public init(field: UInt32) {

--- a/core/data/tests/can_recognize_types_inside_modules/output.ts
+++ b/core/data/tests/can_recognize_types_inside_modules/output.ts
@@ -2,11 +2,11 @@ export interface A {
 	field: number;
 }
 
-export interface ABC {
+export interface AB {
 	field: number;
 }
 
-export interface AB {
+export interface ABC {
 	field: number;
 }
 

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -2,11 +2,11 @@ package proto
 
 import "encoding/json"
 
+type SomeEnum string
+const (
+)
 type TestEnum string
 const (
 	TestEnumVariant1 TestEnum = "Variant1"
 	TestEnumVariant5 TestEnum = "Variant5"
-)
-type SomeEnum string
-const (
 )

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -4,14 +4,14 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
+enum class SomeEnum(val string: String) {
+}
+
+@Serializable
 enum class TestEnum(val string: String) {
 	@SerialName("Variant1")
 	Variant1("Variant1"),
 	@SerialName("Variant5")
 	Variant5("Variant5"),
-}
-
-@Serializable
-enum class SomeEnum(val string: String) {
 }
 

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -2,6 +2,12 @@ package com.agilebits
 
 package onepassword {
 
+sealed trait SomeEnum {
+	def serialName: String
+}
+object SomeEnum {
+}
+
 sealed trait TestEnum {
 	def serialName: String
 }
@@ -12,12 +18,6 @@ object TestEnum {
 	case object Variant5 extends TestEnum {
 		val serialName: String = "Variant5"
 	}
-}
-
-sealed trait SomeEnum {
-	def serialName: String
-}
-object SomeEnum {
 }
 
 }

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -1,9 +1,9 @@
 import Foundation
 
+public enum SomeEnum: String, Codable {
+}
+
 public enum TestEnum: String, Codable {
 	case variant1 = "Variant1"
 	case variant5 = "Variant5"
-}
-
-public enum SomeEnum: String, Codable {
 }

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -1,8 +1,8 @@
+export enum SomeEnum {
+}
+
 export enum TestEnum {
 	Variant1 = "Variant1",
 	Variant5 = "Variant5",
-}
-
-export enum SomeEnum {
 }
 

--- a/core/data/tests/generate_types_with_keywords/output.swift
+++ b/core/data/tests/generate_types_with_keywords/output.swift
@@ -10,11 +10,6 @@ public struct `catch`: Codable {
 	}
 }
 
-public enum `throws`: String, Codable {
-	case `case`
-	case `default`
-}
-
 public enum `switch`: Codable {
 	case `default`(`catch`)
 
@@ -48,4 +43,9 @@ public enum `switch`: Codable {
 			try container.encode(content, forKey: .content)
 		}
 	}
+}
+
+public enum `throws`: String, Codable {
+	case `case`
+	case `default`
 }

--- a/core/data/tests/orders_types/output.go
+++ b/core/data/tests/orders_types/output.go
@@ -11,10 +11,10 @@ type B struct {
 type C struct {
 	DependsOn B `json:"dependsOn"`
 }
+type E struct {
+	DependsOn D `json:"dependsOn"`
+}
 type D struct {
 	DependsOn C `json:"dependsOn"`
 	AlsoDependsOn *E `json:"alsoDependsOn,omitempty"`
-}
-type E struct {
-	DependsOn D `json:"dependsOn"`
 }

--- a/core/data/tests/orders_types/output.kt
+++ b/core/data/tests/orders_types/output.kt
@@ -19,13 +19,13 @@ data class C (
 )
 
 @Serializable
-data class D (
-	val dependsOn: C,
-	val alsoDependsOn: E? = null
+data class E (
+	val dependsOn: D
 )
 
 @Serializable
-data class E (
-	val dependsOn: D
+data class D (
+	val dependsOn: C,
+	val alsoDependsOn: E? = null
 )
 

--- a/core/data/tests/orders_types/output.swift
+++ b/core/data/tests/orders_types/output.swift
@@ -24,6 +24,14 @@ public struct C: Codable {
 	}
 }
 
+public struct E: Codable {
+	public let dependsOn: D
+
+	public init(dependsOn: D) {
+		self.dependsOn = dependsOn
+	}
+}
+
 public struct D: Codable {
 	public let dependsOn: C
 	public let alsoDependsOn: E?
@@ -31,13 +39,5 @@ public struct D: Codable {
 	public init(dependsOn: C, alsoDependsOn: E?) {
 		self.dependsOn = dependsOn
 		self.alsoDependsOn = alsoDependsOn
-	}
-}
-
-public struct E: Codable {
-	public let dependsOn: D
-
-	public init(dependsOn: D) {
-		self.dependsOn = dependsOn
 	}
 }

--- a/core/data/tests/recursive_enum_decorator/output.go
+++ b/core/data/tests/recursive_enum_decorator/output.go
@@ -2,88 +2,6 @@ package proto
 
 import "encoding/json"
 
-type OptionsTypes string
-const (
-	OptionsTypeVariantRed OptionsTypes = "Red"
-	OptionsTypeVariantBanana OptionsTypes = "Banana"
-	OptionsTypeVariantVermont OptionsTypes = "Vermont"
-)
-type Options struct{ 
-	Type OptionsTypes `json:"type"`
-	content interface{}
-}
-
-func (o *Options) UnmarshalJSON(data []byte) error {
-	var enum struct {
-		Tag    OptionsTypes   `json:"type"`
-		Content json.RawMessage `json:"content"`
-	}
-	if err := json.Unmarshal(data, &enum); err != nil {
-		return err
-	}
-
-	o.Type = enum.Tag
-	switch o.Type {
-	case OptionsTypeVariantRed:
-		var res bool
-		o.content = &res
-	case OptionsTypeVariantBanana:
-		var res string
-		o.content = &res
-	case OptionsTypeVariantVermont:
-		var res Options
-		o.content = &res
-
-	}
-	if err := json.Unmarshal(enum.Content, &o.content); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (o Options) MarshalJSON() ([]byte, error) {
-    var enum struct {
-		Tag    OptionsTypes   `json:"type"`
-		Content interface{} `json:"content,omitempty"`
-    }
-    enum.Tag = o.Type
-    enum.Content = o.content
-    return json.Marshal(enum)
-}
-
-func (o Options) Red() bool {
-	res, _ := o.content.(*bool)
-	return *res
-}
-func (o Options) Banana() string {
-	res, _ := o.content.(*string)
-	return *res
-}
-func (o Options) Vermont() Options {
-	res, _ := o.content.(*Options)
-	return *res
-}
-
-func NewOptionsTypeVariantRed(content bool) Options {
-    return Options{
-        Type: OptionsTypeVariantRed,
-        content: &content,
-    }
-}
-func NewOptionsTypeVariantBanana(content string) Options {
-    return Options{
-        Type: OptionsTypeVariantBanana,
-        content: &content,
-    }
-}
-func NewOptionsTypeVariantVermont(content Options) Options {
-    return Options{
-        Type: OptionsTypeVariantVermont,
-        content: &content,
-    }
-}
-
 // Generated type representing the anonymous struct variant `Exactly` of the `MoreOptions` Rust enum
 type MoreOptionsExactlyInner struct {
 	Config string `json:"config"`
@@ -171,6 +89,88 @@ func NewMoreOptionsTypeVariantBuilt(content *MoreOptionsBuiltInner) MoreOptions 
     return MoreOptions{
         Type: MoreOptionsTypeVariantBuilt,
         content: content,
+    }
+}
+
+type OptionsTypes string
+const (
+	OptionsTypeVariantRed OptionsTypes = "Red"
+	OptionsTypeVariantBanana OptionsTypes = "Banana"
+	OptionsTypeVariantVermont OptionsTypes = "Vermont"
+)
+type Options struct{ 
+	Type OptionsTypes `json:"type"`
+	content interface{}
+}
+
+func (o *Options) UnmarshalJSON(data []byte) error {
+	var enum struct {
+		Tag    OptionsTypes   `json:"type"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &enum); err != nil {
+		return err
+	}
+
+	o.Type = enum.Tag
+	switch o.Type {
+	case OptionsTypeVariantRed:
+		var res bool
+		o.content = &res
+	case OptionsTypeVariantBanana:
+		var res string
+		o.content = &res
+	case OptionsTypeVariantVermont:
+		var res Options
+		o.content = &res
+
+	}
+	if err := json.Unmarshal(enum.Content, &o.content); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o Options) MarshalJSON() ([]byte, error) {
+    var enum struct {
+		Tag    OptionsTypes   `json:"type"`
+		Content interface{} `json:"content,omitempty"`
+    }
+    enum.Tag = o.Type
+    enum.Content = o.content
+    return json.Marshal(enum)
+}
+
+func (o Options) Red() bool {
+	res, _ := o.content.(*bool)
+	return *res
+}
+func (o Options) Banana() string {
+	res, _ := o.content.(*string)
+	return *res
+}
+func (o Options) Vermont() Options {
+	res, _ := o.content.(*Options)
+	return *res
+}
+
+func NewOptionsTypeVariantRed(content bool) Options {
+    return Options{
+        Type: OptionsTypeVariantRed,
+        content: &content,
+    }
+}
+func NewOptionsTypeVariantBanana(content string) Options {
+    return Options{
+        Type: OptionsTypeVariantBanana,
+        content: &content,
+    }
+}
+func NewOptionsTypeVariantVermont(content Options) Options {
+    return Options{
+        Type: OptionsTypeVariantVermont,
+        content: &content,
     }
 }
 

--- a/core/data/tests/recursive_enum_decorator/output.kt
+++ b/core/data/tests/recursive_enum_decorator/output.kt
@@ -3,19 +3,6 @@ package com.agilebits.onepassword
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
-@Serializable
-sealed class Options {
-	@Serializable
-	@SerialName("red")
-	data class Red(val content: Boolean): Options()
-	@Serializable
-	@SerialName("banana")
-	data class Banana(val content: String): Options()
-	@Serializable
-	@SerialName("vermont")
-	data class Vermont(val content: Options): Options()
-}
-
 /// Generated type representing the anonymous struct variant `Exactly` of the `MoreOptions` Rust enum
 @Serializable
 data class MoreOptionsExactlyInner (
@@ -39,5 +26,18 @@ sealed class MoreOptions {
 	@Serializable
 	@SerialName("built")
 	data class Built(val content: MoreOptionsBuiltInner): MoreOptions()
+}
+
+@Serializable
+sealed class Options {
+	@Serializable
+	@SerialName("red")
+	data class Red(val content: Boolean): Options()
+	@Serializable
+	@SerialName("banana")
+	data class Banana(val content: String): Options()
+	@Serializable
+	@SerialName("vermont")
+	data class Vermont(val content: Options): Options()
 }
 

--- a/core/data/tests/recursive_enum_decorator/output.scala
+++ b/core/data/tests/recursive_enum_decorator/output.scala
@@ -2,21 +2,6 @@ package com.agilebits
 
 package onepassword {
 
-sealed trait Options {
-	def serialName: String
-}
-object Options {
-	case class Red(content: Boolean) extends Options {
-		val serialName: String = "red"
-	}
-	case class Banana(content: String) extends Options {
-		val serialName: String = "banana"
-	}
-	case class Vermont(content: Options) extends Options {
-		val serialName: String = "vermont"
-	}
-}
-
 // Generated type representing the anonymous struct variant `Exactly` of the `MoreOptions` Rust enum
 case class MoreOptionsExactlyInner (
 	config: String
@@ -39,6 +24,21 @@ object MoreOptions {
 	}
 	case class Built(content: MoreOptionsBuiltInner) extends MoreOptions {
 		val serialName: String = "built"
+	}
+}
+
+sealed trait Options {
+	def serialName: String
+}
+object Options {
+	case class Red(content: Boolean) extends Options {
+		val serialName: String = "red"
+	}
+	case class Banana(content: String) extends Options {
+		val serialName: String = "banana"
+	}
+	case class Vermont(content: Options) extends Options {
+		val serialName: String = "vermont"
 	}
 }
 

--- a/core/data/tests/recursive_enum_decorator/output.swift
+++ b/core/data/tests/recursive_enum_decorator/output.swift
@@ -1,60 +1,5 @@
 import Foundation
 
-public indirect enum Options: Codable {
-	case red(Bool)
-	case banana(String)
-	case vermont(Options)
-
-	enum CodingKeys: String, CodingKey, Codable {
-		case red,
-			banana,
-			vermont
-	}
-
-	private enum ContainerCodingKeys: String, CodingKey {
-		case type, content
-	}
-
-	public init(from decoder: Decoder) throws {
-		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
-		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
-			switch type {
-			case .red:
-				if let content = try? container.decode(Bool.self, forKey: .content) {
-					self = .red(content)
-					return
-				}
-			case .banana:
-				if let content = try? container.decode(String.self, forKey: .content) {
-					self = .banana(content)
-					return
-				}
-			case .vermont:
-				if let content = try? container.decode(Options.self, forKey: .content) {
-					self = .vermont(content)
-					return
-				}
-			}
-		}
-		throw DecodingError.typeMismatch(Options.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for Options"))
-	}
-
-	public func encode(to encoder: Encoder) throws {
-		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
-		switch self {
-		case .red(let content):
-			try container.encode(CodingKeys.red, forKey: .type)
-			try container.encode(content, forKey: .content)
-		case .banana(let content):
-			try container.encode(CodingKeys.banana, forKey: .type)
-			try container.encode(content, forKey: .content)
-		case .vermont(let content):
-			try container.encode(CodingKeys.vermont, forKey: .type)
-			try container.encode(content, forKey: .content)
-		}
-	}
-}
-
 
 /// Generated type representing the anonymous struct variant `Exactly` of the `MoreOptions` Rust enum
 public struct MoreOptionsExactlyInner: Codable {
@@ -123,6 +68,61 @@ public indirect enum MoreOptions: Codable {
 			try container.encode(content, forKey: .content)
 		case .built(let content):
 			try container.encode(CodingKeys.built, forKey: .type)
+			try container.encode(content, forKey: .content)
+		}
+	}
+}
+
+public indirect enum Options: Codable {
+	case red(Bool)
+	case banana(String)
+	case vermont(Options)
+
+	enum CodingKeys: String, CodingKey, Codable {
+		case red,
+			banana,
+			vermont
+	}
+
+	private enum ContainerCodingKeys: String, CodingKey {
+		case type, content
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
+		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
+			switch type {
+			case .red:
+				if let content = try? container.decode(Bool.self, forKey: .content) {
+					self = .red(content)
+					return
+				}
+			case .banana:
+				if let content = try? container.decode(String.self, forKey: .content) {
+					self = .banana(content)
+					return
+				}
+			case .vermont:
+				if let content = try? container.decode(Options.self, forKey: .content) {
+					self = .vermont(content)
+					return
+				}
+			}
+		}
+		throw DecodingError.typeMismatch(Options.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for Options"))
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
+		switch self {
+		case .red(let content):
+			try container.encode(CodingKeys.red, forKey: .type)
+			try container.encode(content, forKey: .content)
+		case .banana(let content):
+			try container.encode(CodingKeys.banana, forKey: .type)
+			try container.encode(content, forKey: .content)
+		case .vermont(let content):
+			try container.encode(CodingKeys.vermont, forKey: .type)
 			try container.encode(content, forKey: .content)
 		}
 	}

--- a/core/data/tests/recursive_enum_decorator/output.ts
+++ b/core/data/tests/recursive_enum_decorator/output.ts
@@ -1,8 +1,3 @@
-export type Options = 
-	| { type: "red", content: boolean }
-	| { type: "banana", content: string }
-	| { type: "vermont", content: Options };
-
 export type MoreOptions = 
 	| { type: "news", content: boolean }
 	| { type: "exactly", content: {
@@ -11,4 +6,9 @@ export type MoreOptions =
 	| { type: "built", content: {
 	top: MoreOptions;
 }};
+
+export type Options = 
+	| { type: "red", content: boolean }
+	| { type: "banana", content: string }
+	| { type: "vermont", content: Options };
 

--- a/core/data/tests/serialize_type_alias/output.go
+++ b/core/data/tests/serialize_type_alias/output.go
@@ -2,12 +2,12 @@ package proto
 
 import "encoding/json"
 
-type AlsoString string
-
 type Uuid string
 
 // Unique identifier for an Account
 type AccountUuid Uuid
+
+type AlsoString string
 
 type ItemUuid string
 

--- a/core/data/tests/serialize_type_alias/output.kt
+++ b/core/data/tests/serialize_type_alias/output.kt
@@ -3,12 +3,12 @@ package com.agilebits.onepassword
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
-typealias AlsoString = String
-
 typealias Uuid = String
 
 /// Unique identifier for an Account
 typealias AccountUuid = Uuid
+
+typealias AlsoString = String
 
 typealias ItemUuid = String
 

--- a/core/data/tests/serialize_type_alias/output.scala
+++ b/core/data/tests/serialize_type_alias/output.scala
@@ -2,13 +2,13 @@ package com.agilebits
 
 package object onepassword {
 
-type AlsoString = String
-
-type Uuid = String
-
 // Unique identifier for an Account
 type AccountUuid = Uuid
 
+type AlsoString = String
+
 type ItemUuid = String
+
+type Uuid = String
 
 }

--- a/core/data/tests/serialize_type_alias/output.swift
+++ b/core/data/tests/serialize_type_alias/output.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-public typealias AlsoString = String
-
 public typealias Uuid = String
 
 /// Unique identifier for an Account
 public typealias AccountUuid = Uuid
+
+public typealias AlsoString = String
 
 public typealias ItemUuid = String

--- a/core/data/tests/serialize_type_alias/output.ts
+++ b/core/data/tests/serialize_type_alias/output.ts
@@ -1,9 +1,9 @@
-export type AlsoString = string;
-
 export type Uuid = string;
 
 /** Unique identifier for an Account */
 export type AccountUuid = Uuid;
+
+export type AlsoString = string;
 
 export type ItemUuid = string;
 

--- a/core/data/tests/smart_pointers/output.go
+++ b/core/data/tests/smart_pointers/output.go
@@ -9,6 +9,19 @@ type ArcyColors struct {
 	Green []string `json:"green"`
 }
 // This is a comment.
+type CellyColors struct {
+	Red string `json:"red"`
+	Blue []string `json:"blue"`
+}
+// This is a comment.
+type CowyColors struct {
+	Lifetime string `json:"lifetime"`
+}
+// This is a comment.
+type LockyColors struct {
+	Red string `json:"red"`
+}
+// This is a comment.
 type MutexyColors struct {
 	Blue []string `json:"blue"`
 	Green string `json:"green"`
@@ -18,19 +31,6 @@ type RcyColors struct {
 	Red string `json:"red"`
 	Blue []string `json:"blue"`
 	Green string `json:"green"`
-}
-// This is a comment.
-type CellyColors struct {
-	Red string `json:"red"`
-	Blue []string `json:"blue"`
-}
-// This is a comment.
-type LockyColors struct {
-	Red string `json:"red"`
-}
-// This is a comment.
-type CowyColors struct {
-	Lifetime string `json:"lifetime"`
 }
 // This is a comment.
 type BoxyColorsTypes string

--- a/core/data/tests/smart_pointers/output.kt
+++ b/core/data/tests/smart_pointers/output.kt
@@ -13,6 +13,25 @@ data class ArcyColors (
 
 /// This is a comment.
 @Serializable
+data class CellyColors (
+	val red: String,
+	val blue: List<String>
+)
+
+/// This is a comment.
+@Serializable
+data class CowyColors (
+	val lifetime: String
+)
+
+/// This is a comment.
+@Serializable
+data class LockyColors (
+	val red: String
+)
+
+/// This is a comment.
+@Serializable
 data class MutexyColors (
 	val blue: List<String>,
 	val green: String
@@ -24,25 +43,6 @@ data class RcyColors (
 	val red: String,
 	val blue: List<String>,
 	val green: String
-)
-
-/// This is a comment.
-@Serializable
-data class CellyColors (
-	val red: String,
-	val blue: List<String>
-)
-
-/// This is a comment.
-@Serializable
-data class LockyColors (
-	val red: String
-)
-
-/// This is a comment.
-@Serializable
-data class CowyColors (
-	val lifetime: String
 )
 
 /// This is a comment.

--- a/core/data/tests/smart_pointers/output.scala
+++ b/core/data/tests/smart_pointers/output.scala
@@ -18,6 +18,22 @@ case class ArcyColors (
 )
 
 // This is a comment.
+case class CellyColors (
+	red: String,
+	blue: Vector[String]
+)
+
+// This is a comment.
+case class CowyColors (
+	lifetime: String
+)
+
+// This is a comment.
+case class LockyColors (
+	red: String
+)
+
+// This is a comment.
 case class MutexyColors (
 	blue: Vector[String],
 	green: String
@@ -28,22 +44,6 @@ case class RcyColors (
 	red: String,
 	blue: Vector[String],
 	green: String
-)
-
-// This is a comment.
-case class CellyColors (
-	red: String,
-	blue: Vector[String]
-)
-
-// This is a comment.
-case class LockyColors (
-	red: String
-)
-
-// This is a comment.
-case class CowyColors (
-	lifetime: String
 )
 
 // This is a comment.

--- a/core/data/tests/smart_pointers/output.swift
+++ b/core/data/tests/smart_pointers/output.swift
@@ -14,6 +14,35 @@ public struct ArcyColors: Codable {
 }
 
 /// This is a comment.
+public struct CellyColors: Codable {
+	public let red: String
+	public let blue: [String]
+
+	public init(red: String, blue: [String]) {
+		self.red = red
+		self.blue = blue
+	}
+}
+
+/// This is a comment.
+public struct CowyColors: Codable {
+	public let lifetime: String
+
+	public init(lifetime: String) {
+		self.lifetime = lifetime
+	}
+}
+
+/// This is a comment.
+public struct LockyColors: Codable {
+	public let red: String
+
+	public init(red: String) {
+		self.red = red
+	}
+}
+
+/// This is a comment.
 public struct MutexyColors: Codable {
 	public let blue: [String]
 	public let green: String
@@ -34,35 +63,6 @@ public struct RcyColors: Codable {
 		self.red = red
 		self.blue = blue
 		self.green = green
-	}
-}
-
-/// This is a comment.
-public struct CellyColors: Codable {
-	public let red: String
-	public let blue: [String]
-
-	public init(red: String, blue: [String]) {
-		self.red = red
-		self.blue = blue
-	}
-}
-
-/// This is a comment.
-public struct LockyColors: Codable {
-	public let red: String
-
-	public init(red: String) {
-		self.red = red
-	}
-}
-
-/// This is a comment.
-public struct CowyColors: Codable {
-	public let lifetime: String
-
-	public init(lifetime: String) {
-		self.lifetime = lifetime
 	}
 }
 

--- a/core/data/tests/smart_pointers/output.ts
+++ b/core/data/tests/smart_pointers/output.ts
@@ -6,6 +6,22 @@ export interface ArcyColors {
 }
 
 /** This is a comment. */
+export interface CellyColors {
+	red: string;
+	blue: string[];
+}
+
+/** This is a comment. */
+export interface CowyColors {
+	lifetime: string;
+}
+
+/** This is a comment. */
+export interface LockyColors {
+	red: string;
+}
+
+/** This is a comment. */
 export interface MutexyColors {
 	blue: string[];
 	green: string;
@@ -16,22 +32,6 @@ export interface RcyColors {
 	red: string;
 	blue: string[];
 	green: string;
-}
-
-/** This is a comment. */
-export interface CellyColors {
-	red: string;
-	blue: string[];
-}
-
-/** This is a comment. */
-export interface LockyColors {
-	red: string;
-}
-
-/** This is a comment. */
-export interface CowyColors {
-	lifetime: string;
 }
 
 /** This is a comment. */

--- a/core/data/tests/test_optional_type_alias/output.go
+++ b/core/data/tests/test_optional_type_alias/output.go
@@ -2,9 +2,9 @@ package proto
 
 import "encoding/json"
 
-type OptionalU32 *uint32
-
 type OptionalU16 *int
+
+type OptionalU32 *uint32
 
 type FooBar struct {
 	Foo OptionalU32 `json:"foo"`

--- a/core/data/tests/test_optional_type_alias/output.kt
+++ b/core/data/tests/test_optional_type_alias/output.kt
@@ -3,9 +3,9 @@ package com.agilebits.onepassword
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
-typealias OptionalU32 = UInt?
-
 typealias OptionalU16 = UShort?
+
+typealias OptionalU32 = UInt?
 
 @Serializable
 data class FooBar (

--- a/core/data/tests/test_optional_type_alias/output.scala
+++ b/core/data/tests/test_optional_type_alias/output.scala
@@ -7,9 +7,9 @@ type UShort = Short
 type UInt = Int
 type ULong = Int
 
-type OptionalU32 = Option[UInt]
-
 type OptionalU16 = Option[UShort]
+
+type OptionalU32 = Option[UInt]
 
 }
 package onepassword {

--- a/core/data/tests/test_optional_type_alias/output.swift
+++ b/core/data/tests/test_optional_type_alias/output.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public typealias OptionalU32 = UInt32?
-
 public typealias OptionalU16 = UInt16?
+
+public typealias OptionalU32 = UInt32?
 
 public struct FooBar: Codable {
 	public let foo: OptionalU32

--- a/core/data/tests/test_optional_type_alias/output.ts
+++ b/core/data/tests/test_optional_type_alias/output.ts
@@ -1,6 +1,6 @@
-export type OptionalU32 = number | undefined;
-
 export type OptionalU16 = number | undefined;
+
+export type OptionalU32 = number | undefined;
 
 export interface FooBar {
 	foo: OptionalU32;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -90,11 +90,11 @@ pub struct ErrorInfo {
 #[derive(Default, Debug)]
 pub struct ParsedData {
     /// Structs defined in the source
-    pub structs: Vec<RustStruct>,
+    pub structs: BTreeSet<RustStruct>,
     /// Enums defined in the source
-    pub enums: Vec<RustEnum>,
+    pub enums: BTreeSet<RustEnum>,
     /// Type aliases defined in the source
-    pub aliases: Vec<RustTypeAlias>,
+    pub aliases: BTreeSet<RustTypeAlias>,
     /// Imports used by this file
     pub import_types: HashSet<ImportedType>,
     /// Crate this belongs to.
@@ -138,15 +138,15 @@ impl ParsedData {
         match rust_thing {
             RustItem::Struct(s) => {
                 self.type_names.insert(s.id.renamed.clone());
-                self.structs.push(s);
+                self.structs.insert(s);
             }
             RustItem::Enum(e) => {
                 self.type_names.insert(e.shared().id.renamed.clone());
-                self.enums.push(e);
+                self.enums.insert(e);
             }
             RustItem::Alias(a) => {
                 self.type_names.insert(a.id.renamed.clone());
-                self.aliases.push(a);
+                self.aliases.insert(a);
             }
         }
     }

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for Id {
 }
 
 /// Rust struct.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct RustStruct {
     /// The identifier for the struct.
     pub id: Id,
@@ -50,11 +50,31 @@ pub struct RustStruct {
     pub decorators: DecoratorMap,
 }
 
+impl PartialEq for RustStruct {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.original == other.id.original
+    }
+}
+
+impl Eq for RustStruct {}
+
+impl PartialOrd for RustStruct {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RustStruct {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id.original.cmp(&other.id.original)
+    }
+}
+
 /// Rust type alias.
 /// ```
 /// pub struct MasterPassword(String);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct RustTypeAlias {
     /// The identifier for the alias.
     pub id: Id,
@@ -64,6 +84,26 @@ pub struct RustTypeAlias {
     pub r#type: RustType,
     /// Comments that were in the type alias source.
     pub comments: Vec<String>,
+}
+
+impl PartialEq for RustTypeAlias {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.original == other.id.original
+    }
+}
+
+impl Eq for RustTypeAlias {}
+
+impl Ord for RustTypeAlias {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.id.original.cmp(&other.id.original)
+    }
+}
+
+impl PartialOrd for RustTypeAlias {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 /// Rust field definition.
@@ -507,7 +547,7 @@ impl SpecialRustType {
 }
 
 /// Parsed information about a Rust enum definition
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum RustEnum {
     /// A unit enum
     ///
@@ -545,6 +585,26 @@ pub enum RustEnum {
         /// Shared context for this enum.
         shared: RustEnumShared,
     },
+}
+
+impl PartialEq for RustEnum {
+    fn eq(&self, other: &Self) -> bool {
+        self.shared().id.original == other.shared().id.original
+    }
+}
+
+impl Eq for RustEnum {}
+
+impl PartialOrd for RustEnum {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RustEnum {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.shared().id.original.cmp(&other.shared().id.original)
+    }
 }
 
 impl RustEnum {


### PR DESCRIPTION
I'm using rayon to walk the folder structure. This prevented the output from being deterministic. To maintain this I updated the mappings and types to maintain sorted collections. As a consequence the tests had to be updated to reflect the new sorting.