### PR TITLE
Add determinism ensurance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,27 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - run: rustup run ${{ matrix.rust }} cargo test --all-features
 
+  
+  check-deterministic:
+    name: Ensure Deterministic Output
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
+        with:
+          just-version: 1
+      - uses: kenji-miyake/setup-sd@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+      - run: rustup toolchain install ${{ matrix.rust }}
+      - run: just --justfile tests/justfile determinism
+    
 
   fmt:
     name: Rustfmt

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+input
+out

--- a/tests/data/determinism-base.rs
+++ b/tests/data/determinism-base.rs
@@ -1,0 +1,16 @@
+#[typeshare]
+pub struct CustomType {}
+
+#[typeshare]
+pub struct Types {
+    pub s: String,
+    pub static_s: &'static str,
+    pub int8: i8,
+    pub float: f32,
+    pub double: f64,
+    pub array: Vec<String>,
+    pub fixed_length_array: [String; 4],
+    pub dictionary: HashMap<String, i32>,
+    pub optional_dictionary: Option<HashMap<String, i32>>,
+    pub custom_type: CustomType,
+}

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,0 +1,19 @@
+determinism_qty := '100'
+
+all: determinism
+
+generate-determinism-files:
+    #!/bin/sh
+    mkdir -p input
+    for i in $(seq 1 {{determinism_qty}}); do
+        cat data/determinism-base.rs | sd '(struct )(\w+)' "\${1}\${2}$i" > "input/input$i.rs"
+    done
+determinism: clean generate-determinism-files
+    mkdir -p out
+    cargo run -p typeshare-cli -- -l typescript -o "out/output1.ts" input
+    cargo run -p typeshare-cli -- -l typescript -o "out/output2.ts" input
+    diff -q out/*.ts
+
+clean:
+    rm -rf out
+    rm -rf input


### PR DESCRIPTION
This creates a new test which can _almost always_ ensure that typeshare output is deterministic. It's a just script for ease of use, and requires just and sd. 

It generates 100 duplicates of a template file (appending the index to the structs in the file), and runs the typeshare CLI twice on the directory. The two outputs are then compared. This test is designed to validate that the order of types are the same even across a large quantity of files. Further tests can be added if necessary to test against a snapshot first generation.