### PR TITLE
Allow multiple target-os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 1.10.0-beta
 
-## 1.10.0-beta.7
+## 1.10.0-beta.8
 
 - Added support for [inline value classes](https://kotlinlang.org/docs/inline-classes.html) in Kotlin - [#182](https://github.com/1Password/typeshare/pull/182)
 - Added the ability to specify that a struct should have information redacted - [#170](https://github.com/1Password/typeshare/pull/170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 1.10.0-beta
 
-## 1.10.0-beta.8
+## 1.10.0-beta.7
 
 - Added support for [inline value classes](https://kotlinlang.org/docs/inline-classes.html) in Kotlin - [#182](https://github.com/1Password/typeshare/pull/182)
 - Added the ability to specify that a struct should have information redacted - [#170](https://github.com/1Password/typeshare/pull/170)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca927478b3747ba47f98af6ba0ac0daea4f12d12f55e9104071b3dc00276310"
+dependencies = [
+ "chrono",
+ "glob",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +394,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +459,18 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -615,7 +656,9 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete_command",
+ "flexi_logger",
  "ignore",
+ "log",
  "once_cell",
  "rayon",
  "serde",
@@ -630,9 +673,11 @@ dependencies = [
  "anyhow",
  "cool_asserts",
  "expect-test",
+ "flexi_logger",
  "itertools",
  "joinery",
  "lazy_format",
+ "log",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -746,6 +791,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.10.0-beta.7"
+version = "1.10.0-beta.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.10.0-beta.7"
+version = "1.10.0-beta.8"
 dependencies = [
  "anyhow",
  "cool_asserts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-cli"
-version = "1.10.0-beta.8"
+version = "1.10.0-beta.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "typeshare-core"
-version = "1.10.0-beta.8"
+version = "1.10.0-beta.7"
 dependencies = [
  "anyhow",
  "cool_asserts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ inherits = "release"
 [workspace.dependencies]
 log = "0.4"
 flexi_logger = "0.28"
-anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ ci = ["github"]
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
-    "x86_64-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-    "aarch64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+  "aarch64-apple-darwin",
 ]
 
 [profile.test]
@@ -32,3 +32,8 @@ incremental = true
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
+
+[workspace.dependencies]
+log = "0.4"
+flexi_logger = "0.28"
+anyhow = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,4 +23,6 @@ rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 typeshare-core = { path = "../core", version = "1.10.0-beta.7" }
-anyhow = "1"
+anyhow.workspace = true
+log.workspace = true
+flexi_logger.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.10.0-beta.7"
+version = "1.10.0-beta.8"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ once_cell = "1"
 rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-typeshare-core = { path = "../core", version = "1.10.0-beta.7" }
+typeshare-core = { path = "../core", version = "1.10.0-beta.8" }
 anyhow.workspace = true
 log.workspace = true
 flexi_logger.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-cli"
-version = "1.10.0-beta.8"
+version = "1.10.0-beta.7"
 edition = "2021"
 description = "Command Line Tool for generating language files with typeshare"
 license = "MIT OR Apache-2.0"
@@ -22,7 +22,7 @@ once_cell = "1"
 rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-typeshare-core = { path = "../core", version = "1.10.0-beta.8" }
+typeshare-core = { path = "../core", version = "1.10.0-beta.7" }
 anyhow.workspace = true
 log.workspace = true
 flexi_logger.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,6 +23,6 @@ rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 typeshare-core = { path = "../core", version = "1.10.0-beta.7" }
-anyhow.workspace = true
 log.workspace = true
 flexi_logger.workspace = true
+anyhow = "1"

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -150,6 +150,7 @@ pub(crate) fn build_command() -> Command<'static> {
                 .min_values(1),
         ).arg(
             Arg::new(ARG_TARGET_OS)
+                .short('t')
                 .long("target-os")
                 .help("Optional restrict to target_os")
                 .takes_value(true)

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -153,6 +153,7 @@ pub(crate) fn build_command() -> Command<'static> {
                 .long("target-os")
                 .help("Optional restrict to target_os")
                 .takes_value(true)
+                .multiple_values(true)
                 .required(false)
         )
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -65,7 +65,7 @@ pub(crate) struct Config {
     #[cfg(feature = "go")]
     pub go: GoParams,
     #[serde(skip)]
-    pub target_os: Option<String>,
+    pub target_os: Vec<String>,
 }
 
 pub(crate) fn store_config(config: &Config, file_path: Option<&str>) -> anyhow::Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,11 @@ mod parse;
 mod writer;
 
 fn main() -> anyhow::Result<()> {
+    flexi_logger::Logger::try_with_env()
+        .unwrap()
+        .start()
+        .unwrap();
+
     #[allow(unused_mut)]
     let mut command = build_command();
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,7 @@ use args::{
 use clap::ArgMatches;
 use config::Config;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
+use log::error;
 use parse::{all_types, parse_input, parser_inputs};
 use rayon::iter::ParallelBridge;
 use std::collections::{BTreeMap, HashMap};
@@ -241,7 +242,7 @@ fn check_parse_errors(parsed_crates: &BTreeMap<CrateName, ParsedData>) -> anyhow
     {
         errors_encountered = true;
         for error in &data.errors {
-            eprintln!(
+            error!(
                 "Parsing error: \"{}\" in crate \"{}\" for file \"{}\"",
                 error.error, error.crate_name, error.file_name
             );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> anyhow::Result<()> {
         parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
         &ignored_types,
         multi_file,
-        target_os,
+        &target_os,
     )?;
 
     // Collect all the types into a map of the file name they
@@ -220,7 +220,10 @@ fn override_configuration(mut config: Config, options: &ArgMatches) -> Config {
         config.go.package = go_package.to_string();
     }
 
-    config.target_os = options.value_of(ARG_TARGET_OS).map(|s| s.to_string());
+    config.target_os = options
+        .get_many::<String>(ARG_TARGET_OS)
+        .map(|arg| arg.into_iter().map(ToString::to_string).collect::<Vec<_>>())
+        .unwrap_or_default();
     config
 }
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -91,7 +91,7 @@ pub fn parse_input(
     inputs: impl ParallelIterator<Item = ParserInput>,
     ignored_types: &[&str],
     multi_file: bool,
-    target_os: Option<String>,
+    target_os: &[String],
 ) -> anyhow::Result<BTreeMap<CrateName, ParsedData>> {
     inputs
         .into_par_iter()
@@ -111,7 +111,7 @@ pub fn parse_input(
                     file_path,
                     ignored_types,
                     multi_file,
-                    target_os.clone(),
+                    target_os,
                 )
                 .with_context(|| format!("Failed to parse: {file_name}"))?;
 

--- a/cli/src/writer.rs
+++ b/cli/src/writer.rs
@@ -2,6 +2,7 @@
 use crate::args::{ARG_OUTPUT_FILE, ARG_OUTPUT_FOLDER};
 use anyhow::Context;
 use clap::ArgMatches;
+use log::info;
 use std::{
     collections::{BTreeMap, HashMap},
     fs,
@@ -58,7 +59,7 @@ fn check_write_file(outfile: &PathBuf, output: Vec<u8>) -> anyhow::Result<()> {
             // avoid writing the file to leave the mtime intact
             // for tools which might use it to know when to
             // rebuild.
-            println!("Skipping writing to {outfile:?} no changes");
+            info!("Skipping writing to {outfile:?} no changes");
             return Ok(());
         }
         _ => {}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-core"
-version = "1.10.0-beta.7"
+version = "1.10.0-beta.8"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "The code generator used by Typeshare's command line tool"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,6 +7,7 @@ description = "The code generator used by Typeshare's command line tool"
 repository = "https://github.com/1Password/typeshare"
 
 [dependencies]
+anyhow.workspace = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "visit"] }
@@ -14,9 +15,10 @@ thiserror = "1"
 itertools = "0.12"
 lazy_format = "2"
 joinery = "2"
+log.workspace = true
+flexi_logger.workspace = true
 
 [dev-dependencies]
-anyhow = "1"
 expect-test = "1.5"
 once_cell = "1"
 cool_asserts = "2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typeshare-core"
-version = "1.10.0-beta.8"
+version = "1.10.0-beta.7"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "The code generator used by Typeshare's command line tool"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,6 @@ description = "The code generator used by Typeshare's command line tool"
 repository = "https://github.com/1Password/typeshare"
 
 [dependencies]
-anyhow.workspace = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "visit"] }
@@ -23,3 +22,4 @@ expect-test = "1.5"
 once_cell = "1"
 cool_asserts = "2"
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
+anyhow = "1"

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -47,3 +47,15 @@ pub struct ManyStruct;
 #[typeshare]
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub struct MultipleTargets;
+
+#[typeshare]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub struct DefinedTwice {
+    field1: u64,
+}
+
+#[typeshare]
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub struct DefinedTwice {
+    field1: String,
+}

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -46,7 +46,7 @@ pub enum Test {}
 pub enum SomeEnum {}
 
 #[typeshare]
-#[cfg(any(target_os = "ios", taget_os = "android"))]
+#[cfg(any(target_os = "ios", target_os = "android"))]
 pub struct ManyStruct;
 
 #[typeshare]

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -21,6 +21,11 @@ pub enum TestEnum {
     },
     #[cfg(any(target_os = "android", target_os = "ios"))]
     Variant8,
+    Variant9 {
+        #[cfg(not(target_os = "macos"))]
+        field1: String,
+        field2: String,
+    },
 }
 
 #[typeshare]

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -59,3 +59,15 @@ pub struct DefinedTwice {
 pub struct DefinedTwice {
     field1: String,
 }
+
+#[typeshare]
+#[cfg(not(any(target_os = "wasm32", target_os = "ios")))]
+pub struct Excluded;
+
+#[typeshare]
+#[cfg(not(target_os = "wasm32"))]
+pub struct OtherExcluded;
+
+#[typeshare]
+#[cfg(not(target_os = "android"))]
+pub struct AndroidExcluded;

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -76,3 +76,7 @@ pub struct OtherExcluded;
 #[typeshare]
 #[cfg(not(target_os = "android"))]
 pub struct AndroidExcluded;
+
+#[typeshare]
+#[cfg(all(feature = "my-feature", not(target_os = "ios")))]
+pub struct NestedNotTarget1;

--- a/core/data/tests/excluded_by_target_os/input.rs
+++ b/core/data/tests/excluded_by_target_os/input.rs
@@ -4,6 +4,7 @@
 use std::collection::HashMap;
 
 #[typeshare]
+#[serde(tag = "type", content = "content")]
 pub enum TestEnum {
     Variant1,
     #[cfg(target_os = "ios")]
@@ -14,6 +15,12 @@ pub enum TestEnum {
     Variant4,
     #[cfg(target_os = "android")]
     Variant5,
+    #[cfg(target_os = "macos")]
+    Variant7 {
+        field1: String,
+    },
+    #[cfg(any(target_os = "android", target_os = "ios"))]
+    Variant8,
 }
 
 #[typeshare]
@@ -32,3 +39,11 @@ pub enum Test {}
 #[cfg(feature = "super")]
 #[cfg(target_os = "android")]
 pub enum SomeEnum {}
+
+#[typeshare]
+#[cfg(any(target_os = "ios", taget_os = "android"))]
+pub struct ManyStruct;
+
+#[typeshare]
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub struct MultipleTargets;

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -5,7 +5,11 @@ import "encoding/json"
 type DefinedTwice struct {
 	Field1 string `json:"field1"`
 }
+type Excluded struct {
+}
 type MultipleTargets struct {
+}
+type OtherExcluded struct {
 }
 type SomeEnum string
 const (

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -2,11 +2,81 @@ package proto
 
 import "encoding/json"
 
+type MultipleTargets struct {
+}
 type SomeEnum string
 const (
 )
-type TestEnum string
+// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
+type TestEnumVariant7Inner struct {
+}
+type TestEnumTypes string
 const (
-	TestEnumVariant1 TestEnum = "Variant1"
-	TestEnumVariant5 TestEnum = "Variant5"
+	TestEnumTypeVariantVariant5 TestEnumTypes = "Variant5"
+	TestEnumTypeVariantVariant7 TestEnumTypes = "Variant7"
+	TestEnumTypeVariantVariant8 TestEnumTypes = "Variant8"
 )
+type TestEnum struct{ 
+	Type TestEnumTypes `json:"type"`
+	content interface{}
+}
+
+func (t *TestEnum) UnmarshalJSON(data []byte) error {
+	var enum struct {
+		Tag    TestEnumTypes   `json:"type"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(data, &enum); err != nil {
+		return err
+	}
+
+	t.Type = enum.Tag
+	switch t.Type {
+	case TestEnumTypeVariantVariant5:
+		return nil
+	case TestEnumTypeVariantVariant7:
+		var res TestEnumVariant7Inner
+		t.content = &res
+	case TestEnumTypeVariantVariant8:
+		return nil
+
+	}
+	if err := json.Unmarshal(enum.Content, &t.content); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t TestEnum) MarshalJSON() ([]byte, error) {
+    var enum struct {
+		Tag    TestEnumTypes   `json:"type"`
+		Content interface{} `json:"content,omitempty"`
+    }
+    enum.Tag = t.Type
+    enum.Content = t.content
+    return json.Marshal(enum)
+}
+
+func (t TestEnum) Variant7() *TestEnumVariant7Inner {
+	res, _ := t.content.(*TestEnumVariant7Inner)
+	return res
+}
+
+func NewTestEnumTypeVariantVariant5() TestEnum {
+    return TestEnum{
+        Type: TestEnumTypeVariantVariant5,
+    }
+}
+func NewTestEnumTypeVariantVariant7(content *TestEnumVariant7Inner) TestEnum {
+    return TestEnum{
+        Type: TestEnumTypeVariantVariant7,
+        content: content,
+    }
+}
+func NewTestEnumTypeVariantVariant8() TestEnum {
+    return TestEnum{
+        Type: TestEnumTypeVariantVariant8,
+    }
+}
+

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -2,6 +2,9 @@ package proto
 
 import "encoding/json"
 
+type DefinedTwice struct {
+	Field1 string `json:"field1"`
+}
 type MultipleTargets struct {
 }
 type SomeEnum string
@@ -9,9 +12,11 @@ const (
 )
 // Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
 type TestEnumVariant7Inner struct {
+	Field1 string `json:"field1"`
 }
 type TestEnumTypes string
 const (
+	TestEnumTypeVariantVariant1 TestEnumTypes = "Variant1"
 	TestEnumTypeVariantVariant5 TestEnumTypes = "Variant5"
 	TestEnumTypeVariantVariant7 TestEnumTypes = "Variant7"
 	TestEnumTypeVariantVariant8 TestEnumTypes = "Variant8"
@@ -32,6 +37,8 @@ func (t *TestEnum) UnmarshalJSON(data []byte) error {
 
 	t.Type = enum.Tag
 	switch t.Type {
+	case TestEnumTypeVariantVariant1:
+		return nil
 	case TestEnumTypeVariantVariant5:
 		return nil
 	case TestEnumTypeVariantVariant7:
@@ -63,6 +70,11 @@ func (t TestEnum) Variant7() *TestEnumVariant7Inner {
 	return res
 }
 
+func NewTestEnumTypeVariantVariant1() TestEnum {
+    return TestEnum{
+        Type: TestEnumTypeVariantVariant1,
+    }
+}
 func NewTestEnumTypeVariantVariant5() TestEnum {
     return TestEnum{
         Type: TestEnumTypeVariantVariant5,

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -11,6 +11,8 @@ type ManyStruct struct {
 }
 type MultipleTargets struct {
 }
+type NestedNotTarget1 struct {
+}
 type OtherExcluded struct {
 }
 type SomeEnum string

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -7,6 +7,8 @@ type DefinedTwice struct {
 }
 type Excluded struct {
 }
+type ManyStruct struct {
+}
 type MultipleTargets struct {
 }
 type OtherExcluded struct {

--- a/core/data/tests/excluded_by_target_os/output.go
+++ b/core/data/tests/excluded_by_target_os/output.go
@@ -18,12 +18,17 @@ const (
 type TestEnumVariant7Inner struct {
 	Field1 string `json:"field1"`
 }
+// Generated type representing the anonymous struct variant `Variant9` of the `TestEnum` Rust enum
+type TestEnumVariant9Inner struct {
+	Field2 string `json:"field2"`
+}
 type TestEnumTypes string
 const (
 	TestEnumTypeVariantVariant1 TestEnumTypes = "Variant1"
 	TestEnumTypeVariantVariant5 TestEnumTypes = "Variant5"
 	TestEnumTypeVariantVariant7 TestEnumTypes = "Variant7"
 	TestEnumTypeVariantVariant8 TestEnumTypes = "Variant8"
+	TestEnumTypeVariantVariant9 TestEnumTypes = "Variant9"
 )
 type TestEnum struct{ 
 	Type TestEnumTypes `json:"type"`
@@ -50,6 +55,9 @@ func (t *TestEnum) UnmarshalJSON(data []byte) error {
 		t.content = &res
 	case TestEnumTypeVariantVariant8:
 		return nil
+	case TestEnumTypeVariantVariant9:
+		var res TestEnumVariant9Inner
+		t.content = &res
 
 	}
 	if err := json.Unmarshal(enum.Content, &t.content); err != nil {
@@ -73,6 +81,10 @@ func (t TestEnum) Variant7() *TestEnumVariant7Inner {
 	res, _ := t.content.(*TestEnumVariant7Inner)
 	return res
 }
+func (t TestEnum) Variant9() *TestEnumVariant9Inner {
+	res, _ := t.content.(*TestEnumVariant9Inner)
+	return res
+}
 
 func NewTestEnumTypeVariantVariant1() TestEnum {
     return TestEnum{
@@ -93,6 +105,12 @@ func NewTestEnumTypeVariantVariant7(content *TestEnumVariant7Inner) TestEnum {
 func NewTestEnumTypeVariantVariant8() TestEnum {
     return TestEnum{
         Type: TestEnumTypeVariantVariant8,
+    }
+}
+func NewTestEnumTypeVariantVariant9(content *TestEnumVariant9Inner) TestEnum {
+    return TestEnum{
+        Type: TestEnumTypeVariantVariant9,
+        content: content,
     }
 }
 

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -12,6 +12,9 @@ data class DefinedTwice (
 object Excluded
 
 @Serializable
+object ManyStruct
+
+@Serializable
 object MultipleTargets
 
 @Serializable

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -27,6 +27,12 @@ data class TestEnumVariant7Inner (
 	val field1: String
 )
 
+/// Generated type representing the anonymous struct variant `Variant9` of the `TestEnum` Rust enum
+@Serializable
+data class TestEnumVariant9Inner (
+	val field2: String
+)
+
 @Serializable
 sealed class TestEnum {
 	@Serializable
@@ -41,5 +47,8 @@ sealed class TestEnum {
 	@Serializable
 	@SerialName("Variant8")
 	object Variant8: TestEnum()
+	@Serializable
+	@SerialName("Variant9")
+	data class Variant9(val content: TestEnumVariant9Inner): TestEnum()
 }
 

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -9,7 +9,13 @@ data class DefinedTwice (
 )
 
 @Serializable
+object Excluded
+
+@Serializable
 object MultipleTargets
+
+@Serializable
+object OtherExcluded
 
 @Serializable
 enum class SomeEnum(val string: String) {

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -18,6 +18,9 @@ object ManyStruct
 object MultipleTargets
 
 @Serializable
+object NestedNotTarget1
+
+@Serializable
 object OtherExcluded
 
 @Serializable

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -4,6 +4,11 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
+data class DefinedTwice (
+	val field1: String
+)
+
+@Serializable
 object MultipleTargets
 
 @Serializable
@@ -12,10 +17,15 @@ enum class SomeEnum(val string: String) {
 
 /// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
 @Serializable
-object TestEnumVariant7Inner
+data class TestEnumVariant7Inner (
+	val field1: String
+)
 
 @Serializable
 sealed class TestEnum {
+	@Serializable
+	@SerialName("Variant1")
+	object Variant1: TestEnum()
 	@Serializable
 	@SerialName("Variant5")
 	object Variant5: TestEnum()

--- a/core/data/tests/excluded_by_target_os/output.kt
+++ b/core/data/tests/excluded_by_target_os/output.kt
@@ -4,14 +4,26 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
 
 @Serializable
+object MultipleTargets
+
+@Serializable
 enum class SomeEnum(val string: String) {
 }
 
+/// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
 @Serializable
-enum class TestEnum(val string: String) {
-	@SerialName("Variant1")
-	Variant1("Variant1"),
+object TestEnumVariant7Inner
+
+@Serializable
+sealed class TestEnum {
+	@Serializable
 	@SerialName("Variant5")
-	Variant5("Variant5"),
+	object Variant5: TestEnum()
+	@Serializable
+	@SerialName("Variant7")
+	data class Variant7(val content: TestEnumVariant7Inner): TestEnum()
+	@Serializable
+	@SerialName("Variant8")
+	object Variant8: TestEnum()
 }
 

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -2,6 +2,10 @@ package com.agilebits
 
 package onepassword {
 
+case class DefinedTwice (
+	field1: String
+)
+
 class MultipleTargets extends Serializable
 
 sealed trait SomeEnum {
@@ -11,12 +15,17 @@ object SomeEnum {
 }
 
 // Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
-class TestEnumVariant7Inner extends Serializable
+case class TestEnumVariant7Inner (
+	field1: String
+)
 
 sealed trait TestEnum {
 	def serialName: String
 }
 object TestEnum {
+	case object Variant1 extends TestEnum {
+		val serialName: String = "Variant1"
+	}
 	case object Variant5 extends TestEnum {
 		val serialName: String = "Variant5"
 	}

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -2,21 +2,29 @@ package com.agilebits
 
 package onepassword {
 
+class MultipleTargets extends Serializable
+
 sealed trait SomeEnum {
 	def serialName: String
 }
 object SomeEnum {
 }
 
+// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
+class TestEnumVariant7Inner extends Serializable
+
 sealed trait TestEnum {
 	def serialName: String
 }
 object TestEnum {
-	case object Variant1 extends TestEnum {
-		val serialName: String = "Variant1"
-	}
 	case object Variant5 extends TestEnum {
 		val serialName: String = "Variant5"
+	}
+	case class Variant7(content: TestEnumVariant7Inner) extends TestEnum {
+		val serialName: String = "Variant7"
+	}
+	case object Variant8 extends TestEnum {
+		val serialName: String = "Variant8"
 	}
 }
 

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -23,6 +23,11 @@ case class TestEnumVariant7Inner (
 	field1: String
 )
 
+// Generated type representing the anonymous struct variant `Variant9` of the `TestEnum` Rust enum
+case class TestEnumVariant9Inner (
+	field2: String
+)
+
 sealed trait TestEnum {
 	def serialName: String
 }
@@ -38,6 +43,9 @@ object TestEnum {
 	}
 	case object Variant8 extends TestEnum {
 		val serialName: String = "Variant8"
+	}
+	case class Variant9(content: TestEnumVariant9Inner) extends TestEnum {
+		val serialName: String = "Variant9"
 	}
 }
 

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -12,6 +12,8 @@ class ManyStruct extends Serializable
 
 class MultipleTargets extends Serializable
 
+class NestedNotTarget1 extends Serializable
+
 class OtherExcluded extends Serializable
 
 sealed trait SomeEnum {

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -6,7 +6,11 @@ case class DefinedTwice (
 	field1: String
 )
 
+class Excluded extends Serializable
+
 class MultipleTargets extends Serializable
+
+class OtherExcluded extends Serializable
 
 sealed trait SomeEnum {
 	def serialName: String

--- a/core/data/tests/excluded_by_target_os/output.scala
+++ b/core/data/tests/excluded_by_target_os/output.scala
@@ -8,6 +8,8 @@ case class DefinedTwice (
 
 class Excluded extends Serializable
 
+class ManyStruct extends Serializable
+
 class MultipleTargets extends Serializable
 
 class OtherExcluded extends Serializable

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -12,6 +12,10 @@ public struct Excluded: Codable {
 	public init() {}
 }
 
+public struct ManyStruct: Codable {
+	public init() {}
+}
+
 public struct MultipleTargets: Codable {
 	public init() {}
 }

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -32,17 +32,28 @@ public struct TestEnumVariant7Inner: Codable {
 		self.field1 = field1
 	}
 }
+
+/// Generated type representing the anonymous struct variant `Variant9` of the `TestEnum` Rust enum
+public struct TestEnumVariant9Inner: Codable {
+	public let field2: String
+
+	public init(field2: String) {
+		self.field2 = field2
+	}
+}
 public enum TestEnum: Codable {
 	case variant1
 	case variant5
 	case variant7(TestEnumVariant7Inner)
 	case variant8
+	case variant9(TestEnumVariant9Inner)
 
 	enum CodingKeys: String, CodingKey, Codable {
 		case variant1 = "Variant1",
 			variant5 = "Variant5",
 			variant7 = "Variant7",
-			variant8 = "Variant8"
+			variant8 = "Variant8",
+			variant9 = "Variant9"
 	}
 
 	private enum ContainerCodingKeys: String, CodingKey {
@@ -67,6 +78,11 @@ public enum TestEnum: Codable {
 			case .variant8:
 				self = .variant8
 				return
+			case .variant9:
+				if let content = try? container.decode(TestEnumVariant9Inner.self, forKey: .content) {
+					self = .variant9(content)
+					return
+				}
 			}
 		}
 		throw DecodingError.typeMismatch(TestEnum.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for TestEnum"))
@@ -84,6 +100,9 @@ public enum TestEnum: Codable {
 			try container.encode(content, forKey: .content)
 		case .variant8:
 			try container.encode(CodingKeys.variant8, forKey: .type)
+		case .variant9(let content):
+			try container.encode(CodingKeys.variant9, forKey: .type)
+			try container.encode(content, forKey: .content)
 		}
 	}
 }

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -1,9 +1,62 @@
 import Foundation
 
+public struct MultipleTargets: Codable {
+	public init() {}
+}
+
 public enum SomeEnum: String, Codable {
 }
 
-public enum TestEnum: String, Codable {
-	case variant1 = "Variant1"
-	case variant5 = "Variant5"
+
+/// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
+public struct TestEnumVariant7Inner: Codable {
+	public init() {}
+}
+public enum TestEnum: Codable {
+	case variant5
+	case variant7(TestEnumVariant7Inner)
+	case variant8
+
+	enum CodingKeys: String, CodingKey, Codable {
+		case variant5 = "Variant5",
+			variant7 = "Variant7",
+			variant8 = "Variant8"
+	}
+
+	private enum ContainerCodingKeys: String, CodingKey {
+		case type, content
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
+		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
+			switch type {
+			case .variant5:
+				self = .variant5
+				return
+			case .variant7:
+				if let content = try? container.decode(TestEnumVariant7Inner.self, forKey: .content) {
+					self = .variant7(content)
+					return
+				}
+			case .variant8:
+				self = .variant8
+				return
+			}
+		}
+		throw DecodingError.typeMismatch(TestEnum.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for TestEnum"))
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
+		switch self {
+		case .variant5:
+			try container.encode(CodingKeys.variant5, forKey: .type)
+		case .variant7(let content):
+			try container.encode(CodingKeys.variant7, forKey: .type)
+			try container.encode(content, forKey: .content)
+		case .variant8:
+			try container.encode(CodingKeys.variant8, forKey: .type)
+		}
+	}
 }

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -8,7 +8,15 @@ public struct DefinedTwice: Codable {
 	}
 }
 
+public struct Excluded: Codable {
+	public init() {}
+}
+
 public struct MultipleTargets: Codable {
+	public init() {}
+}
+
+public struct OtherExcluded: Codable {
 	public init() {}
 }
 

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+public struct DefinedTwice: Codable {
+	public let field1: String
+
+	public init(field1: String) {
+		self.field1 = field1
+	}
+}
+
 public struct MultipleTargets: Codable {
 	public init() {}
 }
@@ -10,15 +18,21 @@ public enum SomeEnum: String, Codable {
 
 /// Generated type representing the anonymous struct variant `Variant7` of the `TestEnum` Rust enum
 public struct TestEnumVariant7Inner: Codable {
-	public init() {}
+	public let field1: String
+
+	public init(field1: String) {
+		self.field1 = field1
+	}
 }
 public enum TestEnum: Codable {
+	case variant1
 	case variant5
 	case variant7(TestEnumVariant7Inner)
 	case variant8
 
 	enum CodingKeys: String, CodingKey, Codable {
-		case variant5 = "Variant5",
+		case variant1 = "Variant1",
+			variant5 = "Variant5",
 			variant7 = "Variant7",
 			variant8 = "Variant8"
 	}
@@ -31,6 +45,9 @@ public enum TestEnum: Codable {
 		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
 		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
 			switch type {
+			case .variant1:
+				self = .variant1
+				return
 			case .variant5:
 				self = .variant5
 				return
@@ -50,6 +67,8 @@ public enum TestEnum: Codable {
 	public func encode(to encoder: Encoder) throws {
 		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
 		switch self {
+		case .variant1:
+			try container.encode(CodingKeys.variant1, forKey: .type)
 		case .variant5:
 			try container.encode(CodingKeys.variant5, forKey: .type)
 		case .variant7(let content):

--- a/core/data/tests/excluded_by_target_os/output.swift
+++ b/core/data/tests/excluded_by_target_os/output.swift
@@ -20,6 +20,10 @@ public struct MultipleTargets: Codable {
 	public init() {}
 }
 
+public struct NestedNotTarget1: Codable {
+	public init() {}
+}
+
 public struct OtherExcluded: Codable {
 	public init() {}
 }

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -2,7 +2,13 @@ export interface DefinedTwice {
 	field1: string;
 }
 
+export interface Excluded {
+}
+
 export interface MultipleTargets {
+}
+
+export interface OtherExcluded {
 }
 
 export enum SomeEnum {

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -1,3 +1,7 @@
+export interface DefinedTwice {
+	field1: string;
+}
+
 export interface MultipleTargets {
 }
 
@@ -5,8 +9,10 @@ export enum SomeEnum {
 }
 
 export type TestEnum = 
+	| { type: "Variant1", content?: undefined }
 	| { type: "Variant5", content?: undefined }
 	| { type: "Variant7", content: {
+	field1: string;
 }}
 	| { type: "Variant8", content?: undefined };
 

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -20,5 +20,8 @@ export type TestEnum =
 	| { type: "Variant7", content: {
 	field1: string;
 }}
-	| { type: "Variant8", content?: undefined };
+	| { type: "Variant8", content?: undefined }
+	| { type: "Variant9", content: {
+	field2: string;
+}};
 

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -1,8 +1,12 @@
+export interface MultipleTargets {
+}
+
 export enum SomeEnum {
 }
 
-export enum TestEnum {
-	Variant1 = "Variant1",
-	Variant5 = "Variant5",
-}
+export type TestEnum = 
+	| { type: "Variant5", content?: undefined }
+	| { type: "Variant7", content: {
+}}
+	| { type: "Variant8", content?: undefined };
 

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -11,6 +11,9 @@ export interface ManyStruct {
 export interface MultipleTargets {
 }
 
+export interface NestedNotTarget1 {
+}
+
 export interface OtherExcluded {
 }
 

--- a/core/data/tests/excluded_by_target_os/output.ts
+++ b/core/data/tests/excluded_by_target_os/output.ts
@@ -5,6 +5,9 @@ export interface DefinedTwice {
 export interface Excluded {
 }
 
+export interface ManyStruct {
+}
+
 export interface MultipleTargets {
 }
 

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     GenerationError,
 };
 use itertools::Itertools;
+use log::warn;
 use proc_macro2::Ident;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
@@ -428,7 +429,7 @@ fn used_imports<'a, 'b: 'a>(
             })
             .next()
         {
-            println!("Warning: Using {crate_name} as module for {ty} which is not in referenced crate {}", referenced_import.base_crate);
+            warn!("Warning: Using {crate_name} as module for {ty} which is not in referenced crate {}", referenced_import.base_crate);
             used.entry(crate_name)
                 .and_modify(|v| {
                     v.insert(ty.as_str());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod language;
 pub mod parser;
 /// Codifying Rust types and how they convert to various languages.
 pub mod rust_types;
+mod target_os_check;
 mod topsort;
 mod visitors;
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -692,6 +692,7 @@ pub(crate) fn target_os_accept(attr: &Attribute, target_os: &str) -> bool {
             if meta_list.path.is_ident("any") || meta_list.path.is_ident("all") {
                 target_os_from_meta_list(meta_list).any(|t| t == target_os)
             } else {
+                // we look for "not" before looking for "accept" so this is ok.
                 true
             }
         }
@@ -741,7 +742,8 @@ fn target_os_parse_not(list: &MetaList, target_os: &str) -> bool {
             }
 
             // The "all" here is treated as any. The assumption is there
-            // will be one "target_os" combined with "feature".
+            // will be one "target_os" combined with "feature" or some other
+            // attribute that is not another "target_os".
             if meta.path.is_ident("any") || meta.path.is_ident("all") {
                 meta.parse_args_with(Punctuated::<MetaNameValue, Token![,]>::parse_terminated)
                     .map(has_target_os)

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -637,6 +637,11 @@ fn is_redacted(attrs: &[syn::Attribute]) -> bool {
 }
 
 /// Check if this attribute rejects our optional `target_os` arguments.
+///
+/// Examples:
+/// - `#[cfg(not(target_os = "windows"))]`
+/// - `#[cfg(not(any(target_os = "windows", target_os = "macos", feature = "my-feature")))]`
+/// - `#[cfg(not(all(target_os = "windows", feature = "my-feature")))]`
 #[inline]
 pub(crate) fn target_os_reject(attr: &Attribute, target_os: &str) -> bool {
     if log_enabled!(log::Level::Debug) {
@@ -660,6 +665,11 @@ pub(crate) fn target_os_reject(attr: &Attribute, target_os: &str) -> bool {
 }
 
 /// Check if this attribute can accept our optional `target_os` arguments.
+///
+/// Examples:
+/// - `#[cfg(target_os = "windows")]`
+/// - `#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]`
+/// - `#[cfg(all(target_os = "windows", feature = "my-feature"))]`
 #[inline]
 pub(crate) fn target_os_accept(attr: &Attribute, target_os: &str) -> bool {
     if log_enabled!(log::Level::Debug) {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -702,15 +702,15 @@ pub(crate) fn target_os_accept(attr: &Attribute, target_os: &str) -> bool {
 fn target_os_parse_not(list: &MetaList, target_os: &str) -> bool {
     let expr: Result<Expr, _> = list.parse_args_with(Expr::parse_without_eager_brace);
 
-    fn parse_target_os(assign: &ExprAssign) -> Option<&Box<Expr>> {
+    fn parse_target_os(assign: &ExprAssign) -> Option<&Expr> {
         match assign.left.as_ref() {
             Expr::Path(p) if p.path.is_ident("target_os") => Some(&assign.right),
             _ => None,
         }
     }
 
-    fn parse_lit(right: &Box<Expr>) -> Option<&Lit> {
-        match right.as_ref() {
+    fn parse_lit(right: &Expr) -> Option<&Lit> {
+        match right {
             Expr::Lit(lit) => Some(&lit.lit),
             _ => None,
         }
@@ -758,8 +758,9 @@ fn target_os_parse_not(list: &MetaList, target_os: &str) -> bool {
                     .and_then(parse_value)
                     .map(|s| s == target_os)
                     .unwrap_or(false),
-                expr => {
-                    debug!("\t\tunexpected expr {expr:?}");
+                _expr => {
+                    #[cfg(test)]
+                    debug!("\t\tunexpected expr {_expr:?}");
                     false
                 }
             }

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -156,6 +156,7 @@ pub enum RustType {
     /// - `SomeStruct<String>`
     /// - `SomeEnum<u32>`
     /// - `SomeTypeAlias<(), &str>`
+    ///
     /// However, there are some generic types that are considered to be _special_. These
     /// include `Vec<T>` `HashMap<K, V>`, and `Option<T>`, which are part of `SpecialRustType` instead
     /// of `RustType::Generic`.

--- a/core/src/target_os_check.rs
+++ b/core/src/target_os_check.rs
@@ -15,14 +15,12 @@ enum TargetScope {
 #[derive(Default)]
 struct TargetOsIterator {
     meta: VecDeque<(TargetScope, Meta)>,
-    // scope: TargetScope,
 }
 
 impl TargetOsIterator {
     fn new(meta: Meta) -> Self {
         Self {
             meta: VecDeque::from([(TargetScope::Accept, meta)]),
-            // ..Default::default()
         }
     }
 }

--- a/core/src/target_os_check.rs
+++ b/core/src/target_os_check.rs
@@ -1,0 +1,298 @@
+//! Optional checks for `#[cfg(target_os = "target")]
+use crate::parser::get_meta_items;
+use log::{debug, error, log_enabled};
+use quote::ToTokens;
+use std::collections::VecDeque;
+use syn::{punctuated::Punctuated, Attribute, Expr, ExprLit, Lit, Meta, Token};
+
+#[derive(Copy, Clone, Default, Debug)]
+enum TargetScope {
+    #[default]
+    Accept,
+    Reject,
+}
+
+#[derive(Default)]
+struct TargetOsIterator {
+    meta: VecDeque<Meta>,
+    scope: TargetScope,
+}
+
+impl TargetOsIterator {
+    fn new(meta: Meta) -> Self {
+        Self {
+            meta: VecDeque::from([meta]),
+            ..Default::default()
+        }
+    }
+}
+
+impl Iterator for TargetOsIterator {
+    type Item = (TargetScope, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(meta) = self.meta.pop_front() {
+            debug!("working on meta");
+            if meta.path().is_ident("not") {
+                debug!("encountered not");
+                self.scope = TargetScope::Reject
+            }
+
+            match meta {
+                Meta::Path(p) => {
+                    debug!("\tencountered path: {p:?}");
+                }
+                Meta::List(meta_list) => {
+                    let nested_meta_list = meta_list
+                        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                        .inspect_err(|err| {
+                            error!("\tfailed to parse nested meta: {err}");
+                        })
+                        .ok()?;
+                    debug!("\texpanding with {} meta", nested_meta_list.len());
+                    self.meta.extend(nested_meta_list);
+                }
+                Meta::NameValue(nv) => {
+                    debug!("\tworking on NameValue: {nv:?}");
+                    if let Some(value) =
+                        nv.path
+                            .is_ident("target_os")
+                            .then_some(nv.value)
+                            .and_then(|value| match value {
+                                Expr::Lit(ExprLit {
+                                    lit: Lit::Str(val), ..
+                                }) => Some(val.value()),
+                                _ => None,
+                            })
+                    {
+                        return Some((self.scope, value));
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+pub(crate) fn accept_target_os(attrs: &[Attribute], target_os: &[String]) -> bool {
+    let (accepted, rejected): (Vec<_>, Vec<_>) = attrs
+        .iter()
+        .inspect(|attr| {
+            if log_enabled!(log::Level::Debug) {
+                debug!(
+                    "\tchecking attribute {} for {target_os:?} accept",
+                    attr.into_token_stream()
+                );
+            }
+        })
+        .flat_map(|attr| get_meta_items(attr, "cfg"))
+        .flat_map(TargetOsIterator::new)
+        .inspect(|val| debug!("Yielded {val:?}"))
+        .partition(|(scope, _)| match scope {
+            TargetScope::Accept => true,
+            TargetScope::Reject => false,
+        });
+
+    debug!("accepted: {accepted:?}, rejected: {rejected:?}");
+
+    let is_rejected = || {
+        target_os
+            .iter()
+            .any(|target| rejected.iter().any(|(_, rejected)| target == rejected))
+    };
+
+    let is_accepted = || {
+        accepted.is_empty()
+            || target_os
+                .iter()
+                .any(|target| accepted.iter().any(|(_, accepted)| accepted == target))
+    };
+
+    !is_rejected() && is_accepted()
+}
+
+#[cfg(test)]
+mod test {
+    use super::accept_target_os;
+    use flexi_logger::DeferredNow;
+    use log::Record;
+    use std::{io::Write, sync::Once};
+    use syn::{parse_quote, ItemStruct};
+
+    static INIT: Once = Once::new();
+
+    fn init_log() {
+        INIT.call_once(|| {
+            flexi_logger::Logger::try_with_env()
+                .unwrap()
+                .format(
+                    |write: &mut dyn Write, _now: &mut DeferredNow, record: &Record<'_>| {
+                        let file_name = record.file().unwrap_or_default();
+                        let file_name = if file_name.len() > 15 {
+                            let split = file_name.len() - 15;
+                            &file_name[split..]
+                        } else {
+                            file_name
+                        };
+                        write!(
+                            write,
+                            "{file_name:>15}{:>5} - {}",
+                            record.line().unwrap_or_default(),
+                            record.args()
+                        )
+                    },
+                )
+                .start()
+                .unwrap();
+        })
+    }
+
+    #[test]
+    fn test_target_os_nested_reject() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(all(feature = "my-feature", not(target_os = "ios")))]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(!accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_target_os_accept() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(target_os = "android")]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_target_os_combined_any_accepted() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(any(target_os = "android", target_os = "ios"))]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_target_os_combined_all_accepted() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(all(target_os = "windows", target_os = "android"))]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_target_os_combined_rejected() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(not(any(target_os = "wasm32", target_os = "ios")))]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(!accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_accept_no_target_os() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(feature = "my-feature")]
+            pub struct NestedNotTarget;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_accept_no_attribute() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            pub struct NestedNotTarget;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["ios".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_accept_none_excluded() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(not(any(target_os = "wasm32", target_os = "ios")))]
+            pub struct Excluded;
+        };
+
+        assert!(accept_target_os(
+            &test_struct.attrs,
+            &["macos".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_reject_not_target_os() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(target_os = "ios")]
+            pub struct Excluded;
+        };
+
+        assert!(!accept_target_os(
+            &test_struct.attrs,
+            &["macos".into(), "android".into()]
+        ));
+    }
+
+    #[test]
+    fn test_any_target_not_target_os() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(any(target_os = "ios", feature = "test"))]
+            pub struct Excluded;
+        };
+
+        assert!(!accept_target_os(
+            &test_struct.attrs,
+            &["macos".into(), "android".into()]
+        ));
+    }
+}

--- a/core/src/target_os_check.rs
+++ b/core/src/target_os_check.rs
@@ -5,6 +5,8 @@ use quote::ToTokens;
 use syn::{punctuated::Punctuated, Attribute, Expr, ExprLit, Lit, Meta, Token};
 
 #[derive(Copy, Clone, Default, Debug)]
+/// Scoped inside a block that either accepts
+/// or rejects.
 enum TargetScope {
     #[default]
     Accept,
@@ -12,11 +14,13 @@ enum TargetScope {
 }
 
 #[derive(Default)]
+/// An iterator that yeilds all meta items and their contained scope.
 struct TargetOsIterator {
     meta: Vec<(TargetScope, Meta)>,
 }
 
 impl TargetOsIterator {
+    /// Create a new nested meta iterator.
     fn new(meta: Meta) -> Self {
         Self {
             meta: Vec::from([(TargetScope::Accept, meta)]),

--- a/core/src/target_os_check.rs
+++ b/core/src/target_os_check.rs
@@ -2,7 +2,6 @@
 use crate::parser::get_meta_items;
 use log::{debug, error, log_enabled, warn};
 use quote::ToTokens;
-use std::collections::VecDeque;
 use syn::{punctuated::Punctuated, Attribute, Expr, ExprLit, Lit, Meta, Token};
 
 #[derive(Copy, Clone, Default, Debug)]
@@ -14,13 +13,13 @@ enum TargetScope {
 
 #[derive(Default)]
 struct TargetOsIterator {
-    meta: VecDeque<(TargetScope, Meta)>,
+    meta: Vec<(TargetScope, Meta)>,
 }
 
 impl TargetOsIterator {
     fn new(meta: Meta) -> Self {
         Self {
-            meta: VecDeque::from([(TargetScope::Accept, meta)]),
+            meta: Vec::from([(TargetScope::Accept, meta)]),
         }
     }
 }
@@ -29,7 +28,7 @@ impl Iterator for TargetOsIterator {
     type Item = (TargetScope, String);
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some((mut scope, meta)) = self.meta.pop_front() {
+        while let Some((mut scope, meta)) = self.meta.pop() {
             if meta.path().is_ident("not") {
                 debug!("encountered not");
                 scope = TargetScope::Reject

--- a/core/src/target_os_check.rs
+++ b/core/src/target_os_check.rs
@@ -311,4 +311,16 @@ mod test {
 
         assert!(accept_target_os(&test_struct.attrs, &["android".into()]))
     }
+
+    #[test]
+    fn test_not_scope_reverse() {
+        init_log();
+
+        let test_struct: ItemStruct = parse_quote! {
+            #[cfg(all(target_os = "android", not(feature = "my-feature")))]
+            pub struct Test;
+        };
+
+        assert!(accept_target_os(&test_struct.attrs, &["android".into()]))
+    }
 }

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -2,10 +2,11 @@
 use crate::{
     language::CrateName,
     parser::{
-        has_typeshare_annotation, parse_enum, parse_struct, parse_type_alias, target_os_accept,
-        target_os_reject, ErrorInfo, ParseError, ParsedData,
+        has_typeshare_annotation, parse_enum, parse_struct, parse_type_alias, ErrorInfo,
+        ParseError, ParsedData,
     },
     rust_types::{RustEnumVariant, RustItem},
+    target_os_check::accept_target_os,
 };
 use log::debug;
 use std::{collections::HashSet, ops::Not, path::PathBuf};
@@ -194,22 +195,7 @@ impl<'a> TypeShareVisitor<'a> {
     /// not match `--target-os` argument?
     #[inline(always)]
     fn target_os_accepted(&self, attrs: &[Attribute]) -> bool {
-        let reject_target = || {
-            !self.target_os.is_empty()
-                && self
-                    .target_os
-                    .iter()
-                    .any(|target| attrs.iter().any(|attr| target_os_reject(attr, target)))
-        };
-
-        let accept_target = || {
-            self.target_os.is_empty()
-                || self
-                    .target_os
-                    .iter()
-                    .any(|target| attrs.iter().all(|attr| target_os_accept(attr, target)))
-        };
-        !reject_target() && accept_target()
+        accept_target_os(attrs, self.target_os)
     }
 }
 

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -19,7 +19,7 @@ pub fn process_input(
         "file_path".into(),
         &[],
         false,
-        None,
+        &[],
     )?
     .unwrap();
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors = ["Jane Lewis", "Josh Rampersad"]
+authors = ["Jane Lewis", "Josh Rampersad", "Darrell Roberts"]
 language = "en"
 multilingual = false
 src = "src"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,4 +5,5 @@
 - [Usage](./usage/usage.md)
     - [Annotations](./usage/annotations.md)
     - [Configuration](./usage/configuration.md)
+    - [Target OS](./usage/target_os.md)
 - [Contributing](./contributing.md)

--- a/docs/src/usage/configuration.md
+++ b/docs/src/usage/configuration.md
@@ -7,16 +7,22 @@ The behaviour of Typeshare can be customized by either passing options on the co
 - `-l`, `--lang`
     (Required) The language you want your definitions to be generated in. Currently, this option can be set to either `kotlin`, `swift`, `go`, or `typescript`.
 - `-o`, `--output-file`
-    (Required) The file path to which the generated definitions will be written.
+    (Required or -d) The file path to which the generated definitions will be written.
+- `-d`, `--directory`
+    (Required or -o) The folder path to write the multiple module files to.
 
 - `-s`, `--swift-prefix`
-    Specify a prefix that will be prepended to type names when generating types in Swift. 
+    Specify a prefix that will be prepended to type names when generating types in Swift.
 
 - `-M`, `--module-name`
-    Specify the name of the Kotlin module for generated Kotlin source code. 
+    Specify the name of the Kotlin module for generated Kotlin source code.
+
+- `-t`, `--target-os`
+    Optional comma separated list of target os targets. Types that are restricted via `#[cfg(target_os = <target>]`
+    that do not match the argument list will be filtered out.
 
 - `-j`, `--java-package`
-    Specify the name of the Java package for generated Kotlin types. 
+    Specify the name of the Java package for generated Kotlin types.
 
 - `-c`, `--config-file`
     Instead of searching for a `typeshare.toml` file, this option can be set to specify the path to the configuration file that Typeshare will use.

--- a/docs/src/usage/target_os.md
+++ b/docs/src/usage/target_os.md
@@ -1,0 +1,87 @@
+# Target OS
+
+The `--target-os` argument is an optional command line argument that allows you to specify a list of comma separated `target_os` values. In your
+Rust source code you can use the [`target_os`](https://doc.rust-lang.org/reference/conditional-compilation.html#target_os) attribute
+to restrict a type, variant or fields.
+
+If you do not use `--target-os` then typeshare will generate all types, variants and fields that are typeshared.
+
+## Example
+```
+./typeshare ./my_rust_project \
+  --lang=typescript \
+  --output-file=my_typescript_definitions.ts \
+  --target-os=linux,macos
+```
+
+The example above is stating any types, variants, fields that are typeshared and are not applicable for `linux` or `macos` will be omitted from
+typeshare type generation.
+
+## Supported `target_os` definitions.
+
+### Simple standalone.
+
+```rust
+#[cfg(target_os = "android")]
+pub struct MyType;
+```
+
+This type will only be generated if `--target-os` has `android` in the list of target_os values.
+
+### Simple not rule
+
+```rust
+#[cfg(not(target_os = "android"))]
+pub struct MyType;
+```
+This type will only be generated if `--target-os` does not include `android` in the list of target_os values.
+
+### Multiple not any rule
+
+```rust
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub struct MyType;
+```
+
+This type will only be generated if `--target-os` does not include `android` or `ios` in the list of target_os values.
+
+The following example will allow `MyType` to be typeshared.
+```
+./typeshare ./my_rust_project \
+  --lang=typescript \
+  --output-file=my_typescript_definitions.ts \
+  --target-os=linux,macos
+```
+
+The following example will not allow `MyType` to be typeshared.
+```
+./typeshare ./my_rust_project \
+  --lang=typescript \
+  --output-file=my_typescript_definitions.ts \
+  --target-os=android,macos
+```
+
+## Combined with features or other cfg attributes
+
+Typehsare will not take into consideration any other `cfg` attributes other than `target_os` when generating types.
+
+For example:
+
+```rust
+#[cfg(any(target_os = "android", feature = "android-test")]
+pub struct MyType;
+```
+
+```rust
+#[cfg(all(target_os = "android", feature = "android-test")]
+pub struct MyType;
+```
+
+```
+./typeshare ./my_rust_project \
+  --lang=typescript \
+  --output-file=my_typescript_definitions.ts \
+  --target-os=android
+```
+
+In both examples above, `MyType` will be typeshared.


### PR DESCRIPTION
* Added support for multiple `--target-os` values. 
* Added support for handling `#[cfg(not(..))]` target_os parsing.
* Updated test in [core/data/tests/excluded_by_target_os/input.rs](https://github.com/darrell-roberts/typeshare/blob/multiple-target-os-option/core/data/tests/excluded_by_target_os/input.rs) to include all possible target_os cfg definitions.
* Added flexi_logger/replaced `println` `eprintln`.

To run the test and see the evaluation:

- `RUST_LOG=debug cargo t --all-features --test snapshot_tests excluded_by_target_os::typescript -- --nocapture`