### PR TITLE
Explicitly format variant types in Go

### DIFF
--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -278,7 +278,6 @@ impl Go {
                     ));
 
                     if let Some(variant_type) = variant_type {
-                        let variant_type = self.acronyms_to_uppercase(&variant_type);
                         let (variant_pointer, variant_deref, variant_ref) =
                             match (v, custom_structs.contains(&variant_type.as_str())) {
                                 (RustEnumVariant::AnonymousStruct { .. }, ..) | (.., true) => {
@@ -287,17 +286,19 @@ impl Go {
                                 _ => ("", "*", "&"),
                             };
 
+                        let formatted_variant_type = self.acronyms_to_uppercase(&variant_type);
+
                         decoding_cases.push(format!(
-                            "\t\tvar res {variant_type}
+                            "\t\tvar res {formatted_variant_type}
 \t\t{short_name}.{content_field} = &res
 ",
-                            variant_type = variant_type,
+                            formatted_variant_type = formatted_variant_type,
                             short_name = struct_short_name,
                             content_field = content_field,
                         ));
                         variant_accessors.push(format!(
-                            r#"func ({short_name} {full_name}) {variant_name}() {variant_pointer}{variant_type} {{
-	res, _ := {short_name}.{content_field}.(*{variant_type})
+                            r#"func ({short_name} {full_name}) {variant_name}() {variant_pointer}{formatted_variant_type} {{
+	res, _ := {short_name}.{content_field}.(*{formatted_variant_type})
 	return {variant_deref}res
 }}
 "#,
@@ -306,11 +307,11 @@ impl Go {
                             variant_name = variant_name,
                             variant_pointer = variant_pointer,
                             variant_deref = variant_deref,
-                            variant_type = variant_type,
+                            formatted_variant_type = formatted_variant_type,
                             content_field = content_field,
                         ));
                         variant_constructors.push(format!(
-                            r#"func New{variant_type_const}(content {variant_pointer}{variant_type}) {struct_name} {{
+                            r#"func New{variant_type_const}(content {variant_pointer}{formatted_variant_type}) {struct_name} {{
     return {struct_name}{{
         {tag_field}: {variant_type_const},
         {content_field}: {variant_ref}content,
@@ -321,7 +322,7 @@ impl Go {
                             tag_field = tag_field,
                             variant_type_const = variant_type_const,
                             variant_pointer = variant_pointer,
-                            variant_type = variant_type,
+                            formatted_variant_type = formatted_variant_type,
                             variant_ref = variant_ref,
                             content_field = content_field,
                         ));

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -156,6 +156,7 @@ pub enum RustType {
     /// - `SomeStruct<String>`
     /// - `SomeEnum<u32>`
     /// - `SomeTypeAlias<(), &str>`
+    ///
     /// However, there are some generic types that are considered to be _special_. These
     /// include `Vec<T>` `HashMap<K, V>`, and `Option<T>`, which are part of `SpecialRustType` instead
     /// of `RustType::Generic`.


### PR DESCRIPTION
## Background

https://github.com/1Password/typeshare/pull/183 introduced an edge-case regression in the handling of custom-typed algebraic enums that require uppercase acronyms handling in Go.

Specifically, the check:
```
custom_structs.contains(&variant_type.as_str())
```
would now fail, since it performs a case-sensitive check in the custom_structs hashmap. While this still produces working code, it does not handle the custom structs as expected. This PR fixes that.

## Effect

The bug consists of code that was previously generated as:
```
func (i ItemFieldDetails) OTP() *OtpFieldDetails {
	res, _ := i.content.(*OtpFieldDetails)
	return res
}
``` 

and would now be generated as:
```
func (i ItemFieldDetails) OTP() OTPFieldDetails {
	res, _ := i.content.(*OTPFieldDetails)
	return *res
}
```

instead of:
```
func (i ItemFieldDetails) OTP() *OTPFieldDetails {
	res, _ := i.content.(*OTPFieldDetails)
	return res
}
```

## Solution

The lookup in the hashmap has been made to leverage the default formatted struct name. However, for generating the Go code, the variant name is formatted with the provided uppercase acronyms.