### PR TITLE
feat: optionally disable wasmbind

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,8 +11,11 @@ repository = "https://github.com/1Password/typeshare"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "std",
-    "wasmbind",
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 typeshare-annotation = { path = "../annotation", version = "1.0.4" }
+
+[features]
+default = ["wasmbind"]
+wasmbind = ["chrono/wasmbind"]


### PR DESCRIPTION
Relevant issue:
https://github.com/1Password/typeshare/issues/191

Make the `chrono/wasmbind` feature optional via `default-features = false` in order to prevent unwanted wasm module exports in environments where interfaces are restricted.