### PR TITLE
Only overwrite Codable.swift if it has changed.

### DIFF
--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -758,12 +758,11 @@ impl Swift {
     fn write_codable_file(&self, output_folder: &str) -> std::io::Result<()> {
         let output_string = self.get_codable_contents();
         let output_path = Path::new(output_folder).join("Codable.swift");
-        match fs::read(output_path.clone()) {
-            Ok(buf) if buf == output_string.as_bytes() => {
-                // don't overwrite the same file, we can bail here
+
+        if let Ok(buf) = fs::read(&output_path) {
+            if buf == output_string.as_bytes() {
                 return Ok(());
             }
-            _ => {}
         }
 
         let mut w = fs::File::create(output_path)?;
@@ -781,7 +780,7 @@ impl Swift {
             decs.push(CODABLE);
         }
 
-        format!("\n/// () isn't codable, so we use this instead to represent Rust's unit type\npublic struct CodableVoid: {} {{}}\n", decs.join(", "))
+        format!("\n/// () isn't codable, so we use this instead to represent Rust's unit type\npublic struct CodableVoid: {} {{}}", decs.join(", "))
     }
 
     /// Write the `CodableVoid` type.

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -14,7 +14,7 @@ use lazy_format::lazy_format;
 use std::{
     borrow::Cow,
     collections::{BTreeSet, HashMap},
-    fs::File,
+    fs,
     io::{self, Write},
     path::Path,
     sync::atomic::{AtomicBool, Ordering},
@@ -231,7 +231,7 @@ impl Language for Swift {
 
     fn end_file(&mut self, w: &mut dyn Write) -> io::Result<()> {
         if self.should_emit_codable_void.load(Ordering::SeqCst) && !self.multi_file {
-            self.write_codable(w)?;
+            self.write_codable(w, &self.get_codable_contents())?;
         }
 
         Ok(())
@@ -756,18 +756,21 @@ impl Swift {
     /// When using multiple file generation we write this into a separate module vs at the
     /// end of the generated file.
     fn write_codable_file(&self, output_folder: &str) -> std::io::Result<()> {
-        let mut w = File::create(Path::new(output_folder).join("Codable.swift"))?;
-        self.write_codable(&mut w)
+        let output_string = self.get_codable_contents();
+        let output_path = Path::new(output_folder).join("Codable.swift");
+        match fs::read(output_path.clone()) {
+            Ok(buf) if buf == output_string.as_bytes() => {
+                // don't overwrite the same file, we can bail here
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        let mut w = fs::File::create(output_path)?;
+        self.write_codable(&mut w, &output_string)
     }
 
-    /// Write the `CodableVoid` type.
-    fn write_codable(&self, w: &mut dyn Write) -> io::Result<()> {
-        writeln!(w)?;
-        writeln!(
-            w,
-            r"/// () isn't codable, so we use this instead to represent Rust's unit type"
-        )?;
-
+    fn get_codable_contents(&self) -> String {
         let mut decs = self
             .get_default_decorators()
             .chain(self.codablevoid_constraints.iter().map(|s| s.as_str()))
@@ -778,7 +781,12 @@ impl Swift {
             decs.push(CODABLE);
         }
 
-        writeln!(w, "public struct CodableVoid: {} {{}}", decs.join(", "))
+        format!("\n/// () isn't codable, so we use this instead to represent Rust's unit type\npublic struct CodableVoid: {} {{}}\n", decs.join(", "))
+    }
+
+    /// Write the `CodableVoid` type.
+    fn write_codable(&self, w: &mut dyn Write, output_string: &str) -> io::Result<()> {
+        writeln!(w, "{}", output_string)
     }
 
     /// Build the generic constraints output. This checks for the `swiftGenericConstraints` typeshare attribute and combines


### PR DESCRIPTION
typeshare was always writing Codable.swift when generating multiple files. The issue is that the updated modification date on Codable.swift would trigger Xcode to rebuild the module, even if there were no changes.

This PR now checks the contents of Codable.swift and only overwrites it if the contents need changing.