### PR TITLE
Set default log level when not using RUST_LOG

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 use anyhow::{anyhow, Context};
 use clap::{CommandFactory, Parser};
 use clap_complete::Generator;
-use flexi_logger::detailed_format;
+use flexi_logger::AdaptiveFormat;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
 use log::{error, info};
 use rayon::iter::ParallelBridge;
@@ -39,8 +39,8 @@ use crate::{
 
 fn main() -> anyhow::Result<()> {
     flexi_logger::Logger::try_with_env_or_str("info")?
-        .format_for_stdout(detailed_format)
-        .format_for_stderr(detailed_format)
+        .adaptive_format_for_stderr(AdaptiveFormat::Detailed)
+        .adaptive_format_for_stdout(AdaptiveFormat::Detailed)
         .start()?;
 
     let options = Args::parse();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -267,8 +267,8 @@ fn check_parse_errors(parsed_crates: &BTreeMap<CrateName, ParsedData>) -> anyhow
         errors_encountered = true;
         for error in &data.errors {
             error!(
-                "Parsing error: \"{}\" in crate \"{}\" for file \"{}\"",
-                error.error, error.crate_name, error.file_name
+                "Parsing error: \"{}\" in file \"{}\"",
+                error.error, error.file_name
             );
         }
     }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -80,8 +80,6 @@ pub enum ParseError {
 /// Error with it's related data.
 #[derive(Debug)]
 pub struct ErrorInfo {
-    /// The crate where this error occurred.
-    pub crate_name: CrateName,
     /// The file name being parsed.
     pub file_name: String,
     /// The parse error.

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -49,7 +49,6 @@ const IGNORED_TYPES: &[&str] = &["Option", "String", "Vec", "HashMap", "T", "I54
 #[derive(Default)]
 pub struct TypeShareVisitor<'a> {
     parsed_data: ParsedData,
-    #[allow(dead_code)]
     file_path: PathBuf,
     ignored_types: &'a [&'a str],
     target_os: &'a [String],

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -92,8 +92,7 @@ impl<'a> TypeShareVisitor<'a> {
         match result {
             Ok(data) => self.parsed_data.push(data),
             Err(error) => self.parsed_data.errors.push(ErrorInfo {
-                crate_name: self.parsed_data.crate_name.clone(),
-                file_name: self.parsed_data.file_name.clone(),
+                file_name: self.file_path.to_string_lossy().into_owned(),
                 error,
             }),
         }


### PR DESCRIPTION
The logger would not initialize unless `RUST_LOG` was defined. 

Fixed this to use default to `info` and allow `RUST_LOG` override.

Fixes: https://github.com/1Password/typeshare/issues/197

Example of parsing errors with change:

```
[2024-11-12 17:34:16.825715 -05:00] INFO [typeshare] cli/src/main.rs:48: typeshare started generating types
[2024-11-12 17:34:18.855152 -05:00] ERROR [typeshare] cli/src/main.rs:269: Parsing error: "the serde tag attribute is not supported for non-algebraic enums: SomeBadEnum" in file "/Users/darrellroberts/projects/my-proj/src/types.rs"
[2024-11-12 17:34:18.855216 -05:00] ERROR [typeshare] cli/src/main.rs:269: Parsing error: "the serde tag attribute is not supported for non-algebraic enums: AnotherBadEnum" in file "/Users/darrellroberts/projects/my-proj/src/types.rs"
[2024-11-12 17:34:18.855230 -05:00] ERROR [typeshare] cli/src/main.rs:269: Parsing error: "the serde tag attribute is not supported for non-algebraic enums: SomeBadEnum" in file "/Users/darrellroberts/projects/my-proj/src/types.rs"
[2024-11-12 17:34:18.855238 -05:00] ERROR [typeshare] cli/src/main.rs:269: Parsing error: "the serde tag attribute is not supported for non-algebraic enums: AnotherBadEnum" in file "/Users/darrellroberts/projects/my-proj/src/types.rs"
[2024-11-12 17:34:18.855252 -05:00] ERROR [typeshare] cli/src/main.rs:277: Errors encountered during parsing.
Error: Errors encountered during parsing.
```


