### PR TITLE
Fix duplicate root added to walker.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> anyhow::Result<()> {
         .overrides(overrides)
         .follow_links(options.follow_links);
 
-    for root in directories {
+    for root in directories.into_iter().skip(1) {
         walker_builder.add(root);
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,6 +73,8 @@ fn main() -> anyhow::Result<()> {
 
     let directories = options.directories.as_slice();
 
+    info!("Using directories: {directories:?}");
+
     let language_type = match options.language {
         None => panic!("no language specified; `clap` should have guaranteed its presence"),
         Some(language) => match language {
@@ -159,6 +161,8 @@ fn main() -> anyhow::Result<()> {
     };
 
     check_parse_errors(&crate_parsed_data)?;
+
+    info!("typeshare started writing generated types");
 
     write_generated(
         destination,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> anyhow::Result<()> {
         .overrides(overrides)
         .follow_links(options.follow_links);
 
-    for root in directories.into_iter().skip(1) {
+    for root in directories.iter().skip(1) {
         walker_builder.add(root);
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,6 +23,7 @@ use rayon::iter::ParallelBridge;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
+    context::ParseContext,
     language::{
         CrateName, GenericConstraints, Kotlin, Language, Scala, SupportedLanguage, Swift,
         TypeScript,
@@ -127,9 +128,13 @@ fn main() -> anyhow::Result<()> {
 
     let multi_file = matches!(destination, Output::Folder(_));
     let target_os = config.target_os.clone();
-
     let mut lang = language(language_type, config, multi_file);
-    let ignored_types = lang.ignored_reference_types();
+
+    let parse_context = ParseContext {
+        ignored_types: lang.ignored_reference_types(),
+        multi_file,
+        target_os,
+    };
 
     // The walker ignores directories that are git-ignored. If you need
     // a git-ignored directory to be processed, add the specific directory to
@@ -141,9 +146,7 @@ fn main() -> anyhow::Result<()> {
     // https://docs.rs/ignore/latest/ignore/struct.WalkParallel.html
     let crate_parsed_data = parse_input(
         parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
-        &ignored_types,
-        multi_file,
-        &target_os,
+        &parse_context,
     )?;
 
     // Collect all the types into a map of the file name they

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -7,6 +7,7 @@ use std::{
     path::PathBuf,
 };
 use typeshare_core::{
+    context::ParseContext,
     language::{CrateName, CrateTypes, SupportedLanguage, SINGLE_FILE_CRATE_NAME},
     parser::ParsedData,
     RenameExt,
@@ -89,9 +90,7 @@ pub fn all_types(file_mappings: &BTreeMap<CrateName, ParsedData>) -> CrateTypes 
 /// Collect all the parsed sources into a mapping of crate name to parsed data.
 pub fn parse_input(
     inputs: impl ParallelIterator<Item = ParserInput>,
-    ignored_types: &[&str],
-    multi_file: bool,
-    target_os: &[String],
+    parse_context: &ParseContext,
 ) -> anyhow::Result<BTreeMap<CrateName, ParsedData>> {
     inputs
         .into_par_iter()
@@ -109,9 +108,7 @@ pub fn parse_input(
                     crate_name.clone(),
                     file_name.clone(),
                     file_path,
-                    ignored_types,
-                    multi_file,
-                    target_os,
+                    parse_context,
                 )
                 .with_context(|| format!("Failed to parse: {file_name}"))?;
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -7,7 +7,7 @@ use std::{
     path::PathBuf,
 };
 use typeshare_core::{
-    context::ParseContext,
+    context::{ParseContext, ParseFileContext},
     language::{CrateName, CrateTypes, SupportedLanguage, SINGLE_FILE_CRATE_NAME},
     parser::ParsedData,
     RenameExt,
@@ -102,15 +102,17 @@ pub fn parse_input(
                  file_name,
                  crate_name,
              }| {
-                let parsed_result = typeshare_core::parser::parse(
-                    &std::fs::read_to_string(&file_path)
+                let parse_file_context = ParseFileContext {
+                    source_code: std::fs::read_to_string(&file_path)
                         .with_context(|| format!("Failed to read input: {file_name}"))?,
-                    crate_name.clone(),
-                    file_name.clone(),
+                    crate_name: crate_name.clone(),
+                    file_name: file_name.clone(),
                     file_path,
-                    parse_context,
-                )
-                .with_context(|| format!("Failed to parse: {file_name}"))?;
+                };
+
+                let parsed_result =
+                    typeshare_core::parser::parse(parse_context, parse_file_context)
+                        .with_context(|| format!("Failed to parse: {file_name}"))?;
 
                 if let Some(parsed_data) = parsed_result {
                     parsed_crates

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,3 +1,5 @@
+//! Context types for parsing.
+//!
 use std::path::PathBuf;
 
 use crate::language::CrateName;
@@ -15,8 +17,12 @@ pub struct ParseContext<'a> {
 
 /// Parsing context for a single rust source file.
 pub struct ParseFileContext {
+    /// Source code content
     pub source_code: String,
+    /// Name of the crate this file belongs to.
     pub crate_name: CrateName,
+    /// File name.
     pub file_name: String,
+    /// Full path to the source file.
     pub file_path: PathBuf,
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,8 +1,7 @@
 //! Context types for parsing.
 //!
-use std::path::PathBuf;
-
 use crate::language::CrateName;
+use std::path::PathBuf;
 
 /// Context for parsing rust source files.
 #[derive(Default)]

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use crate::language::CrateName;
+
+/// Context for parsing rust source files.
+#[derive(Default)]
+pub struct ParseContext<'a> {
+    /// Types to ignore
+    pub ignored_types: Vec<&'a str>,
+    /// Multi file output enabled.
+    pub multi_file: bool,
+    /// `target_os` filtering.
+    pub target_os: Vec<String>,
+}
+
+/// Parsing context for a single rust source file.
+pub struct ParseFileContext<'a> {
+    pub source_code: &'a str,
+    pub crate_name: CrateName,
+    pub file_name: String,
+    pub file_path: PathBuf,
+}

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -14,8 +14,8 @@ pub struct ParseContext<'a> {
 }
 
 /// Parsing context for a single rust source file.
-pub struct ParseFileContext<'a> {
-    pub source_code: &'a str,
+pub struct ParseFileContext {
+    pub source_code: String,
     pub crate_name: CrateName,
     pub file_name: String,
     pub file_path: PathBuf,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,14 +1,13 @@
 //! The core library for typeshare.
 //! Contains the parser and language converters.
-
 use thiserror::Error;
 
-mod rename;
-
+pub mod context;
 /// Implementations for each language converter
 pub mod language;
 /// Parsing Rust code into a format the `language` modules can understand
 pub mod parser;
+mod rename;
 /// Codifying Rust types and how they convert to various languages.
 pub mod rust_types;
 mod target_os_check;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,4 +1,5 @@
 use crate::{
+    context::ParseContext,
     language::{CrateName, SupportedLanguage},
     rename::RenameExt,
     rust_types::{
@@ -166,9 +167,7 @@ pub fn parse(
     crate_name: CrateName,
     file_name: String,
     file_path: PathBuf,
-    ignored_types: &[&str],
-    mult_file: bool,
-    target_os: &[String],
+    parse_context: &ParseContext,
 ) -> Result<Option<ParsedData>, ParseError> {
     // We will only produce output for files that contain the `#[typeshare]`
     // attribute, so this is a quick and easy performance win
@@ -179,14 +178,7 @@ pub fn parse(
     debug!("parsing {file_name}");
     // Parse and process the input, ensuring we parse only items marked with
     // `#[typeshare]`
-    let mut import_visitor = TypeShareVisitor::new(
-        crate_name,
-        file_name,
-        file_path,
-        ignored_types,
-        mult_file,
-        target_os,
-    );
+    let mut import_visitor = TypeShareVisitor::new(crate_name, file_name, file_path, parse_context);
     import_visitor.visit_file(&syn::parse_file(source_code)?);
 
     Ok(import_visitor.parsed_data())

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -47,7 +47,6 @@ const IGNORED_TYPES: &[&str] = &["Option", "String", "Vec", "HashMap", "T", "I54
 
 /// An import visitor that collects all use or
 /// qualified referenced items.
-// #[derive(Default)]
 pub struct TypeShareVisitor<'a> {
     parsed_data: ParsedData,
     file_path: PathBuf,

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -57,10 +57,10 @@ pub struct TypeShareVisitor<'a> {
 impl<'a> TypeShareVisitor<'a> {
     /// Create an import visitor for a given crate name.
     pub fn new(
+        parse_context: &'a ParseContext<'a>,
         crate_name: CrateName,
         file_name: String,
         file_path: PathBuf,
-        parse_context: &'a ParseContext<'a>,
     ) -> Self {
         Self {
             parsed_data: ParsedData::new(crate_name, file_name, parse_context.multi_file),
@@ -615,10 +615,10 @@ mod test {
 
         let file: File = syn::parse_str(rust_code).unwrap();
         let mut visitor = TypeShareVisitor::new(
+            &parse_context,
             "my_crate".into(),
             "my_file".into(),
             "file_path".into(),
-            &parse_context,
         );
         visitor.visit_file(&file);
 

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -1,5 +1,6 @@
 //! Visitors to collect various items from the AST.
 use crate::{
+    context::ParseContext,
     language::CrateName,
     parser::{
         has_typeshare_annotation, parse_enum, parse_struct, parse_type_alias, ErrorInfo,
@@ -46,12 +47,11 @@ const IGNORED_TYPES: &[&str] = &["Option", "String", "Vec", "HashMap", "T", "I54
 
 /// An import visitor that collects all use or
 /// qualified referenced items.
-#[derive(Default)]
+// #[derive(Default)]
 pub struct TypeShareVisitor<'a> {
     parsed_data: ParsedData,
     file_path: PathBuf,
-    ignored_types: &'a [&'a str],
-    target_os: &'a [String],
+    parse_context: &'a ParseContext<'a>,
 }
 
 impl<'a> TypeShareVisitor<'a> {
@@ -60,15 +60,12 @@ impl<'a> TypeShareVisitor<'a> {
         crate_name: CrateName,
         file_name: String,
         file_path: PathBuf,
-        ignored_types: &'a [&'a str],
-        multi_file: bool,
-        target_os: &'a [String],
+        parse_context: &'a ParseContext<'a>,
     ) -> Self {
         Self {
-            parsed_data: ParsedData::new(crate_name, file_name, multi_file),
+            parsed_data: ParsedData::new(crate_name, file_name, parse_context.multi_file),
             file_path,
-            ignored_types,
-            target_os,
+            parse_context,
         }
     }
 
@@ -193,7 +190,7 @@ impl<'a> TypeShareVisitor<'a> {
     /// not match `--target-os` argument?
     #[inline(always)]
     fn target_os_accepted(&self, attrs: &[Attribute]) -> bool {
-        accept_target_os(attrs, self.target_os)
+        accept_target_os(attrs, &self.parse_context.target_os)
     }
 }
 
@@ -224,7 +221,10 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
 
             (accept_crate(&crate_candidate)
                 && accept_type(&type_candidate)
-                && !self.ignored_types.contains(&type_candidate.as_str())
+                && !self
+                    .parse_context
+                    .ignored_types
+                    .contains(&type_candidate.as_str())
                 && crate_candidate != type_candidate)
                 .then(|| {
                     // resolve crate and super aliases into the crate name.
@@ -254,10 +254,14 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         if !self.parsed_data.multi_file {
             return;
         }
-        self.parsed_data.import_types.extend(
-            parse_import(i, &self.parsed_data.crate_name)
-                .filter(|imp| !self.ignored_types.contains(&imp.type_name.as_str())),
-        );
+        self.parsed_data
+            .import_types
+            .extend(parse_import(i, &self.parsed_data.crate_name).filter(|imp| {
+                !self
+                    .parse_context
+                    .ignored_types
+                    .contains(&imp.type_name.as_str())
+            }));
         syn::visit::visit_item_use(self, i);
     }
 
@@ -266,7 +270,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         debug!("Visiting {}", i.ident);
         if has_typeshare_annotation(&i.attrs) && self.target_os_accepted(&i.attrs) {
             debug!("\tParsing {}", i.ident);
-            self.collect_result(parse_struct(i, self.target_os));
+            self.collect_result(parse_struct(i, &self.parse_context.target_os));
         }
 
         syn::visit::visit_item_struct(self, i);
@@ -277,7 +281,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         debug!("Visiting {}", i.ident);
         if has_typeshare_annotation(&i.attrs) && self.target_os_accepted(&i.attrs) {
             debug!("\tParsing {}", i.ident);
-            self.collect_result(parse_enum(i, self.target_os));
+            self.collect_result(parse_enum(i, &self.parse_context.target_os));
         }
 
         syn::visit::visit_item_enum(self, i);
@@ -432,7 +436,7 @@ fn parse_import<'a>(
 #[cfg(test)]
 mod test {
     use super::{parse_import, TypeShareVisitor};
-    use crate::visitors::ImportedType;
+    use crate::{context::ParseContext, visitors::ImportedType};
     use cool_asserts::assert_matches;
     use itertools::Itertools;
     use syn::{visit::Visit, File};
@@ -603,14 +607,18 @@ mod test {
             }
             ";
 
+        let parse_context = ParseContext {
+            ignored_types: Vec::new(),
+            multi_file: true,
+            target_os: Vec::new(),
+        };
+
         let file: File = syn::parse_str(rust_code).unwrap();
         let mut visitor = TypeShareVisitor::new(
             "my_crate".into(),
             "my_file".into(),
             "file_path".into(),
-            &[],
-            true,
-            &[],
+            &parse_context,
         );
         visitor.visit_file(&file);
 

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use typeshare_core::{
-    context::ParseContext,
+    context::{ParseContext, ParseFileContext},
     language::{CrateTypes, Language, TypeScript},
     parser::{self, ParseError},
     rust_types::RustTypeParseError,
@@ -16,11 +16,13 @@ pub fn process_input(
     let parse_context = ParseContext::default();
 
     let mut parsed_data = parser::parse(
-        input,
-        "default_name".into(),
-        "file_name".into(),
-        "file_path".into(),
         &parse_context,
+        ParseFileContext {
+            source_code: input.to_string(),
+            crate_name: "default_name".into(),
+            file_name: "file_name".into(),
+            file_path: "file_path".into(),
+        },
     )?
     .unwrap();
 

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
 use typeshare_core::{
+    context::ParseContext,
     language::{CrateTypes, Language, TypeScript},
     parser::{self, ParseError},
     rust_types::RustTypeParseError,
@@ -12,14 +13,14 @@ pub fn process_input(
     imports: &CrateTypes,
     out: &mut dyn Write,
 ) -> Result<(), ProcessInputError> {
+    let parse_context = ParseContext::default();
+
     let mut parsed_data = parser::parse(
         input,
         "default_name".into(),
         "file_name".into(),
         "file_path".into(),
-        &[],
-        false,
-        &[],
+        &parse_context,
     )?
     .unwrap();
 

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -10,7 +10,10 @@ use std::{
     path::{Path, PathBuf},
     sync::Once,
 };
-use typeshare_core::{context::ParseContext, language::Language};
+use typeshare_core::{
+    context::{ParseContext, ParseFileContext},
+    language::Language,
+};
 
 static TESTS_FOLDER_PATH: Lazy<PathBuf> =
     Lazy::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/tests"));
@@ -103,11 +106,13 @@ fn check(
     };
 
     let parsed_data = typeshare_core::parser::parse(
-        &rust_input,
-        "default_crate".into(),
-        "file_name".into(),
-        "file_path".into(),
         &parse_context,
+        ParseFileContext {
+            source_code: rust_input,
+            crate_name: "default_crate".into(),
+            file_name: "file_name".into(),
+            file_path: "file_path".into(),
+        },
     )?
     .unwrap();
     lang.generate_types(&mut typeshare_output, &HashMap::new(), parsed_data)?;

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Once,
 };
-use typeshare_core::language::Language;
+use typeshare_core::{context::ParseContext, language::Language};
 
 static TESTS_FOLDER_PATH: Lazy<PathBuf> =
     Lazy::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/tests"));
@@ -97,17 +97,17 @@ fn check(
     )?;
 
     let mut typeshare_output: Vec<u8> = Vec::new();
+    let parse_context = ParseContext {
+        target_os: target_os.iter().map(ToString::to_string).collect(),
+        ..Default::default()
+    };
+
     let parsed_data = typeshare_core::parser::parse(
         &rust_input,
         "default_crate".into(),
         "file_name".into(),
         "file_path".into(),
-        &[],
-        false,
-        &target_os
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>(),
+        &parse_context,
     )?
     .unwrap();
     lang.generate_types(&mut typeshare_output, &HashMap::new(), parsed_data)?;


### PR DESCRIPTION
I found that we are adding the root directory to the walker twice, resulting in parsing each input file twice.

Refactored the parsing API to use a `ParseContext` and a `ParseFileContext` for improved readability.