### PR TITLE
Approach to handle serde(rename) references.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,7 +19,6 @@ use clap_complete::Generator;
 use flexi_logger::AdaptiveFormat;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
 use log::{error, info};
-use parse::reconcile_aliases;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
@@ -29,6 +28,7 @@ use typeshare_core::{
         TypeScript,
     },
     parser::ParsedData,
+    reconcile::reconcile_aliases,
 };
 
 use crate::{
@@ -147,7 +147,6 @@ fn main() -> anyhow::Result<()> {
     // data. That way both walking and parsing are in parallel.
     // https://docs.rs/ignore/latest/ignore/struct.WalkParallel.html
     let mut crate_parsed_data = parse_input(
-        // parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
         parser_inputs(walker_builder, language_type, multi_file),
         &parse_context,
     )?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,8 +47,6 @@ fn main() -> anyhow::Result<()> {
 
     let options = Args::parse();
 
-    info!("typeshare started generating types");
-
     if let Some(options) = options.subcommand {
         match options {
             Command::Completions { shell } => {
@@ -68,6 +66,8 @@ fn main() -> anyhow::Result<()> {
         config::store_config(&config, config_file).context("Failed to create new config file")?;
         return Ok(());
     }
+
+    info!("typeshare started generating types");
 
     let config = config::load_config(config_file).context("Unable to read configuration file")?;
     let config = override_configuration(config, &options)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -19,6 +19,7 @@ use clap_complete::Generator;
 use flexi_logger::AdaptiveFormat;
 use ignore::{overrides::OverrideBuilder, types::TypesBuilder, WalkBuilder};
 use log::{error, info};
+use rayon::iter::ParallelBridge;
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
 use typeshare_core::{
@@ -147,7 +148,7 @@ fn main() -> anyhow::Result<()> {
     // data. That way both walking and parsing are in parallel.
     // https://docs.rs/ignore/latest/ignore/struct.WalkParallel.html
     let mut crate_parsed_data = parse_input(
-        parser_inputs(walker_builder, language_type, multi_file),
+        parser_inputs(walker_builder, language_type, multi_file).par_bridge(),
         &parse_context,
     )?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -77,8 +77,6 @@ fn main() -> anyhow::Result<()> {
 fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<()> {
     info!("typeshare started generating types");
 
-    info!("typeshare started generating types");
-
     let config = config::load_config(config_file).context("Unable to read configuration file")?;
     let config = override_configuration(config, options)?;
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -1,7 +1,7 @@
 //! Source file parsing.
 use anyhow::Context;
 use ignore::WalkBuilder;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use log::{debug, info};
 use std::{
     collections::{hash_map::Entry, BTreeMap, HashMap},
     path::PathBuf,
@@ -10,6 +10,7 @@ use typeshare_core::{
     context::{ParseContext, ParseFileContext},
     language::{CrateName, CrateTypes, SupportedLanguage, SINGLE_FILE_CRATE_NAME},
     parser::ParsedData,
+    rust_types::{RustEnum, RustEnumVariant, RustType, SpecialRustType},
     RenameExt,
 };
 
@@ -89,45 +90,128 @@ pub fn all_types(file_mappings: &BTreeMap<CrateName, ParsedData>) -> CrateTypes 
 
 /// Collect all the parsed sources into a mapping of crate name to parsed data.
 pub fn parse_input(
-    inputs: impl ParallelIterator<Item = ParserInput>,
+    mut inputs: impl Iterator<Item = ParserInput>,
     parse_context: &ParseContext,
 ) -> anyhow::Result<BTreeMap<CrateName, ParsedData>> {
-    inputs
-        .into_par_iter()
-        .try_fold(
-            BTreeMap::new,
-            |mut parsed_crates: BTreeMap<CrateName, ParsedData>,
-             ParserInput {
-                 file_path,
-                 file_name,
-                 crate_name,
-             }| {
-                let parse_file_context = ParseFileContext {
-                    source_code: std::fs::read_to_string(&file_path)
-                        .with_context(|| format!("Failed to read input: {file_name}"))?,
-                    crate_name: crate_name.clone(),
-                    file_name: file_name.clone(),
-                    file_path,
-                };
+    inputs.try_fold(
+        BTreeMap::new(),
+        |mut parsed_crates: BTreeMap<CrateName, ParsedData>,
+         ParserInput {
+             file_path,
+             file_name,
+             crate_name,
+         }| {
+            let fp = file_path.as_os_str().to_str().unwrap_or("").to_string();
 
-                let parsed_result =
-                    typeshare_core::parser::parse(parse_context, parse_file_context)
-                        .with_context(|| format!("Failed to parse: {file_name}"))?;
+            let parse_file_context = ParseFileContext {
+                source_code: std::fs::read_to_string(&file_path)
+                    .with_context(|| format!("Failed to read input: {file_path:?}"))?,
+                crate_name: crate_name.clone(),
+                file_name: file_name.clone(),
+                file_path,
+            };
 
-                if let Some(parsed_data) = parsed_result {
-                    parsed_crates
-                        .entry(crate_name)
-                        .or_default()
-                        .add(parsed_data);
-                }
+            let parsed_result = typeshare_core::parser::parse(parse_context, parse_file_context)
+                .with_context(|| format!("Failed to parse: {fp}"))?;
 
-                Ok(parsed_crates)
-            },
-        )
-        .try_reduce(BTreeMap::new, |mut file_maps, parsed_crates| {
-            for (crate_name, parsed_data) in parsed_crates {
-                file_maps.entry(crate_name).or_default().add(parsed_data);
+            if let Some(parsed_data) = parsed_result {
+                parsed_crates
+                    .entry(crate_name)
+                    .or_default()
+                    .add(parsed_data);
             }
-            Ok(file_maps)
-        })
+
+            Ok(parsed_crates)
+        },
+    )
+}
+
+/// Update any type references that have the refenced type renamed via `serde(rename)`.
+pub fn reconcile_aliases(crate_parsed_data: &mut BTreeMap<CrateName, ParsedData>) {
+    for (_crate_name, parsed_data) in crate_parsed_data {
+        let serde_renamed = parsed_data
+            .structs
+            .iter()
+            .flat_map(|s| {
+                s.id.serde_rename
+                    .then_some((s.id.original.to_string(), s.id.renamed.to_string()))
+            })
+            .chain(parsed_data.enums.iter().flat_map(|e| {
+                e.shared().id.serde_rename.then_some((
+                    e.shared().id.original.to_string(),
+                    e.shared().id.renamed.to_string(),
+                ))
+            }))
+            .collect::<HashMap<_, _>>();
+
+        // find references to original ids and update accordingly
+        for s in &mut parsed_data.structs {
+            debug!("struct: {}", s.id.original);
+            for f in &mut s.fields {
+                check_type(&serde_renamed, &mut f.ty);
+            }
+        }
+
+        for e in &mut parsed_data.enums {
+            debug!("enum: {}", e.shared().id.original);
+            match e {
+                RustEnum::Unit(shared) => check_variant(&serde_renamed, &mut shared.variants),
+                RustEnum::Algebraic { shared, .. } => {
+                    check_variant(&serde_renamed, &mut shared.variants)
+                }
+            }
+        }
+    }
+}
+
+fn check_variant(serde_renamed: &HashMap<String, String>, variants: &mut Vec<RustEnumVariant>) {
+    for v in variants {
+        match v {
+            RustEnumVariant::Unit(_) => (),
+            RustEnumVariant::Tuple { ty, .. } => {
+                check_type(serde_renamed, ty);
+            }
+            RustEnumVariant::AnonymousStruct { fields, .. } => {
+                for f in fields {
+                    check_type(serde_renamed, &mut f.ty);
+                }
+            }
+        }
+    }
+}
+
+fn check_type(serde_renamed: &HashMap<String, String>, ty: &mut RustType) {
+    debug!("checking type: {ty:?}");
+    match ty {
+        RustType::Generic { parameters, .. } => {
+            for ty in parameters {
+                check_type(serde_renamed, ty);
+            }
+        }
+        RustType::Special(s) => match s {
+            SpecialRustType::Vec(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::Array(ty, _) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::Slice(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::HashMap(ty1, ty2) => {
+                check_type(serde_renamed, ty1);
+                check_type(serde_renamed, ty2);
+            }
+            SpecialRustType::Option(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            _ => (),
+        },
+        RustType::Simple { id } => {
+            if let Some(alias) = serde_renamed.get(id) {
+                info!("renaming type from {id} to {alias}");
+                *id = alias.to_string()
+            }
+        }
+    }
 }

--- a/core/README.md
+++ b/core/README.md
@@ -34,7 +34,7 @@ The test suite can of course be run normally without updating any expectations:
 cargo test -p typeshare-core
 ```
 
-If you find yourself needing to update expectations for a specific test only, run the following (subsituting the name of your test in for the last arg):
+If you find yourself needing to update expectations for a specific test only, run the following (substituting the name of your test in for the last arg):
 
 ```
 env UPDATE_EXPECT=1 cargo test -p typeshare-core --test snapshot_tests -- can_handle_serde_rename_all::swift

--- a/core/data/tests/serde_rename_references/input.rs
+++ b/core/data/tests/serde_rename_references/input.rs
@@ -1,0 +1,27 @@
+//! Test references to a type that has been renamed via serde(rename)
+//!
+
+#[derive(Serialize)]
+#[serde(rename = "SomethingFoo")]
+#[typeshare]
+pub enum Foo {
+    A,
+}
+
+#[derive(Serialize)]
+#[typeshare]
+#[serde(tag = "type", content = "value")]
+pub enum Parent {
+    B(Foo),
+}
+
+#[derive(Serialize)]
+#[typeshare]
+pub struct Test {
+    field1: Foo,
+    field2: Option<Foo>,
+}
+
+#[derive(Serialize)]
+#[typeshare]
+pub type AliasTest = Vec<Foo>;

--- a/core/data/tests/serde_rename_references/output.go
+++ b/core/data/tests/serde_rename_references/output.go
@@ -1,0 +1,68 @@
+package proto
+
+import "encoding/json"
+
+type AliasTest []SomethingFoo
+
+type Test struct {
+	Field1 SomethingFoo `json:"field1"`
+	Field2 *SomethingFoo `json:"field2,omitempty"`
+}
+type Foo string
+const (
+	FooA Foo = "A"
+)
+type ParentTypes string
+const (
+	ParentTypeVariantB ParentTypes = "B"
+)
+type Parent struct{ 
+	Type ParentTypes `json:"type"`
+	value interface{}
+}
+
+func (p *Parent) UnmarshalJSON(data []byte) error {
+	var enum struct {
+		Tag    ParentTypes   `json:"type"`
+		Content json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(data, &enum); err != nil {
+		return err
+	}
+
+	p.Type = enum.Tag
+	switch p.Type {
+	case ParentTypeVariantB:
+		var res SomethingFoo
+		p.value = &res
+
+	}
+	if err := json.Unmarshal(enum.Content, &p.value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p Parent) MarshalJSON() ([]byte, error) {
+    var enum struct {
+		Tag    ParentTypes   `json:"type"`
+		Content interface{} `json:"value,omitempty"`
+    }
+    enum.Tag = p.Type
+    enum.Content = p.value
+    return json.Marshal(enum)
+}
+
+func (p Parent) B() SomethingFoo {
+	res, _ := p.value.(*SomethingFoo)
+	return *res
+}
+
+func NewParentTypeVariantB(content SomethingFoo) Parent {
+    return Parent{
+        Type: ParentTypeVariantB,
+        value: &content,
+    }
+}
+

--- a/core/data/tests/serde_rename_references/output.kt
+++ b/core/data/tests/serde_rename_references/output.kt
@@ -1,0 +1,26 @@
+package com.agilebits.onepassword
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+typealias AliasTest = List<SomethingFoo>
+
+@Serializable
+data class Test (
+	val field1: SomethingFoo,
+	val field2: SomethingFoo? = null
+)
+
+@Serializable
+enum class SomethingFoo(val string: String) {
+	@SerialName("A")
+	A("A"),
+}
+
+@Serializable
+sealed class Parent {
+	@Serializable
+	@SerialName("B")
+	data class B(val value: SomethingFoo): Parent()
+}
+

--- a/core/data/tests/serde_rename_references/output.scala
+++ b/core/data/tests/serde_rename_references/output.scala
@@ -1,0 +1,33 @@
+package com.agilebits
+
+package object onepassword {
+
+type AliasTest = Vector[SomethingFoo]
+
+}
+package onepassword {
+
+case class Test (
+	field1: SomethingFoo,
+	field2: Option[SomethingFoo] = None
+)
+
+sealed trait SomethingFoo {
+	def serialName: String
+}
+object SomethingFoo {
+	case object A extends SomethingFoo {
+		val serialName: String = "A"
+	}
+}
+
+sealed trait Parent {
+	def serialName: String
+}
+object Parent {
+	case class B(value: SomethingFoo) extends Parent {
+		val serialName: String = "B"
+	}
+}
+
+}

--- a/core/data/tests/serde_rename_references/output.swift
+++ b/core/data/tests/serde_rename_references/output.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+public typealias AliasTest = [SomethingFoo]
+
+public struct Test: Codable {
+	public let field1: SomethingFoo
+	public let field2: SomethingFoo?
+
+	public init(field1: SomethingFoo, field2: SomethingFoo?) {
+		self.field1 = field1
+		self.field2 = field2
+	}
+}
+
+public enum SomethingFoo: String, Codable {
+	case a = "A"
+}
+
+public enum Parent: Codable {
+	case b(SomethingFoo)
+
+	enum CodingKeys: String, CodingKey, Codable {
+		case b = "B"
+	}
+
+	private enum ContainerCodingKeys: String, CodingKey {
+		case type, value
+	}
+
+	public init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: ContainerCodingKeys.self)
+		if let type = try? container.decode(CodingKeys.self, forKey: .type) {
+			switch type {
+			case .b:
+				if let content = try? container.decode(SomethingFoo.self, forKey: .value) {
+					self = .b(content)
+					return
+				}
+			}
+		}
+		throw DecodingError.typeMismatch(Parent.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for Parent"))
+	}
+
+	public func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: ContainerCodingKeys.self)
+		switch self {
+		case .b(let content):
+			try container.encode(CodingKeys.b, forKey: .type)
+			try container.encode(content, forKey: .value)
+		}
+	}
+}

--- a/core/data/tests/serde_rename_references/output.ts
+++ b/core/data/tests/serde_rename_references/output.ts
@@ -1,0 +1,14 @@
+export type AliasTest = SomethingFoo[];
+
+export interface Test {
+	field1: SomethingFoo;
+	field2?: SomethingFoo;
+}
+
+export enum SomethingFoo {
+	A = "A",
+}
+
+export type Parent = 
+	| { type: "B", value: SomethingFoo };
+

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -130,6 +130,7 @@ impl Language for Kotlin {
                     id: Id {
                         original: String::from("value"),
                         renamed: String::from("value"),
+                        serde_rename: false,
                     },
                     ty: ty.r#type.clone(),
                     comments: vec![],

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -379,6 +379,7 @@ pub trait Language {
                     id: Id {
                         original: struct_name.clone(),
                         renamed: struct_name.clone(),
+                        serde_rename: false
                     },
                     fields: fields.clone(),
                     generic_types,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod context;
 pub mod language;
 /// Parsing Rust code into a format the `language` modules can understand
 pub mod parser;
+pub mod reconcile;
 mod rename;
 /// Codifying Rust types and how they convert to various languages.
 pub mod rust_types;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -11,7 +11,7 @@ use crate::{
     visitors::{ImportedType, TypeShareVisitor},
 };
 use itertools::Either;
-use log::debug;
+use log::{debug, info};
 use proc_macro2::Ident;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -90,11 +90,11 @@ pub struct ErrorInfo {
 #[derive(Default, Debug)]
 pub struct ParsedData {
     /// Structs defined in the source
-    pub structs: BTreeSet<RustStruct>,
+    pub structs: Vec<RustStruct>,
     /// Enums defined in the source
-    pub enums: BTreeSet<RustEnum>,
+    pub enums: Vec<RustEnum>,
     /// Type aliases defined in the source
-    pub aliases: BTreeSet<RustTypeAlias>,
+    pub aliases: Vec<RustTypeAlias>,
     /// Imports used by this file
     pub import_types: HashSet<ImportedType>,
     /// Crate this belongs to.
@@ -138,15 +138,15 @@ impl ParsedData {
         match rust_thing {
             RustItem::Struct(s) => {
                 self.type_names.insert(s.id.renamed.clone());
-                self.structs.insert(s);
+                self.structs.push(s);
             }
             RustItem::Enum(e) => {
                 self.type_names.insert(e.shared().id.renamed.clone());
-                self.enums.insert(e);
+                self.enums.push(e);
             }
             RustItem::Alias(a) => {
                 self.type_names.insert(a.id.renamed.clone());
-                self.aliases.insert(a);
+                self.aliases.push(a);
             }
         }
     }
@@ -178,7 +178,7 @@ pub fn parse(
         file_path,
     } = parse_file_context;
 
-    debug!("parsing {file_name}");
+    info!("parsing {file_path:?}");
     // Parse and process the input, ensuring we parse only items marked with
     // `#[typeshare]`
     let mut import_visitor = TypeShareVisitor::new(parse_context, crate_name, file_name, file_path);
@@ -554,11 +554,17 @@ fn get_ident(
 
     let mut renamed = rename_all_to_case(original.clone(), rename_all);
 
+    let mut renamed_via_serde_rename = false;
     if let Some(s) = serde_rename(attrs) {
         renamed = s;
+        renamed_via_serde_rename = true;
     }
 
-    Id { original, renamed }
+    Id {
+        original,
+        renamed,
+        serde_rename: renamed_via_serde_rename,
+    }
 }
 
 fn rename_all_to_case(original: String, case: &Option<String>) -> String {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -11,7 +11,7 @@ use crate::{
     visitors::{ImportedType, TypeShareVisitor},
 };
 use itertools::Either;
-use log::{debug, info};
+use log::debug;
 use proc_macro2::Ident;
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -178,7 +178,7 @@ pub fn parse(
         file_path,
     } = parse_file_context;
 
-    info!("parsing {file_path:?}");
+    debug!("parsing {file_path:?}");
     // Parse and process the input, ensuring we parse only items marked with
     // `#[typeshare]`
     let mut import_visitor = TypeShareVisitor::new(parse_context, crate_name, file_name, file_path);

--- a/core/src/reconcile.rs
+++ b/core/src/reconcile.rs
@@ -177,7 +177,7 @@ fn resolve_renamed(
     // Find in imports.
     import_types
         .iter()
-        .filter(|i| &i.type_name == id)
+        .filter(|i| i.type_name == id)
         .find_map(|import_ref| name_map.get(&import_ref.base_crate))
         // Fallback to looking up in our current namespace.
         .or_else(|| name_map.get(crate_name))

--- a/core/src/reconcile.rs
+++ b/core/src/reconcile.rs
@@ -1,0 +1,117 @@
+//! Post reconcile references after all types have been parsed.
+//!
+//! Types can be renamed via `serde(rename = "NewName")`. These types will get the new
+//! name however we still need to see if we have any other types that reference the renamed type
+//! and update those references accordingly.
+use crate::{
+    language::CrateName,
+    parser::ParsedData,
+    rust_types::{RustEnum, RustEnumVariant, RustType, SpecialRustType},
+};
+use log::{debug, info};
+use std::collections::{BTreeMap, HashMap};
+
+/// Update any type references that have the refenced type renamed via `serde(rename)`.
+pub fn reconcile_aliases(crate_parsed_data: &mut BTreeMap<CrateName, ParsedData>) {
+    for (_crate_name, parsed_data) in crate_parsed_data {
+        // TODO: This assumes the reference and reference type are both in the same crate namespace.
+        // This will be fine if multi-file is not used however if multi-file is used and the reference
+        // type and it's references are in separate crates it will not.
+        let serde_renamed = parsed_data
+            .structs
+            .iter()
+            .flat_map(|s| {
+                s.id.serde_rename
+                    .then_some((s.id.original.to_string(), s.id.renamed.to_string()))
+            })
+            .chain(parsed_data.enums.iter().flat_map(|e| {
+                e.shared().id.serde_rename.then_some((
+                    e.shared().id.original.to_string(),
+                    e.shared().id.renamed.to_string(),
+                ))
+            }))
+            .chain(parsed_data.aliases.iter().flat_map(|e| {
+                e.id.serde_rename
+                    .then(|| (e.id.original.to_string(), e.id.renamed.to_string()))
+            }))
+            .collect::<HashMap<_, _>>();
+
+        // find references to original ids and update accordingly
+        for s in &mut parsed_data.structs {
+            debug!("struct: {}", s.id.original);
+            for f in &mut s.fields {
+                check_type(&serde_renamed, &mut f.ty);
+            }
+        }
+
+        for e in &mut parsed_data.enums {
+            debug!("enum: {}", e.shared().id.original);
+            match e {
+                RustEnum::Unit(shared) => check_variant(&serde_renamed, &mut shared.variants),
+                RustEnum::Algebraic { shared, .. } => {
+                    check_variant(&serde_renamed, &mut shared.variants)
+                }
+            }
+        }
+
+        for a in &mut parsed_data.aliases {
+            check_type(&serde_renamed, &mut a.r#type);
+        }
+
+        parsed_data.structs.sort();
+        parsed_data.enums.sort();
+        parsed_data.aliases.sort();
+    }
+}
+
+fn check_variant(serde_renamed: &HashMap<String, String>, variants: &mut Vec<RustEnumVariant>) {
+    for v in variants {
+        match v {
+            RustEnumVariant::Unit(_) => (),
+            RustEnumVariant::Tuple { ty, .. } => {
+                check_type(serde_renamed, ty);
+            }
+            RustEnumVariant::AnonymousStruct { fields, .. } => {
+                for f in fields {
+                    check_type(serde_renamed, &mut f.ty);
+                }
+            }
+        }
+    }
+}
+
+fn check_type(serde_renamed: &HashMap<String, String>, ty: &mut RustType) {
+    debug!("checking type: {ty:?}");
+    match ty {
+        RustType::Generic { parameters, .. } => {
+            for ty in parameters {
+                check_type(serde_renamed, ty);
+            }
+        }
+        RustType::Special(s) => match s {
+            SpecialRustType::Vec(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::Array(ty, _) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::Slice(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            SpecialRustType::HashMap(ty1, ty2) => {
+                check_type(serde_renamed, ty1);
+                check_type(serde_renamed, ty2);
+            }
+            SpecialRustType::Option(ty) => {
+                check_type(serde_renamed, ty);
+            }
+            _ => (),
+        },
+        RustType::Simple { id } => {
+            if let Some(alias) = serde_renamed.get(id) {
+                info!("renaming type from {id} to {alias}");
+                *id = alias.to_string()
+            }
+        }
+    }
+}

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -21,6 +21,8 @@ pub struct Id {
     /// If there is no re-naming going on, this will be identical to
     /// `original`.
     pub renamed: String,
+    /// Was this renamed with `serde(rename = "newname")
+    pub serde_rename: bool,
 }
 
 impl std::fmt::Display for Id {

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -193,7 +193,7 @@ impl<'a> TypeShareVisitor<'a> {
     }
 }
 
-impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
+impl<'ast> Visit<'ast> for TypeShareVisitor<'_> {
     /// Find any reference types that are not part of
     /// the `use` import statements.
     fn visit_path(&mut self, p: &'ast syn::Path) {
@@ -297,7 +297,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         syn::visit::visit_item_type(self, i);
     }
 
-    /// Track potentially skipped modules.
+    // Track potentially skipped modules.
     // fn visit_item_mod(&mut self, i: &'ast syn::ItemMod) {
     //     if let Some(target_os) = self.target_os.as_ref() {
     //         if i.attrs.iter().any(|attr| target_os_skip(attr, target_os)) {
@@ -383,7 +383,7 @@ impl<'a> ItemUseIter<'a> {
     }
 }
 
-impl<'a> Iterator for ItemUseIter<'a> {
+impl Iterator for ItemUseIter<'_> {
     type Item = ImportedType;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
I added a post parsing reconcile step that updates reference types that refer to a type that has been renamed via `serde(rename)`. 

https://github.com/1Password/typeshare/issues/201