### PR TITLE
Only assert if go package is present if generating go types

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -256,7 +256,7 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
         if let Some(go_package) = options.go_package.as_ref() {
             config.go.package = go_package.to_string();
         }
-        
+
         if let Some(go_lang) = options.language {
             assert_go_package_present(&config)?;
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -256,7 +256,10 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
         if let Some(go_package) = options.go_package.as_ref() {
             config.go.package = go_package.to_string();
         }
-        assert_go_package_present(&config)?;
+        
+        if let Some(go_lang) = options.language {
+            assert_go_package_present(&config)?;
+        }
     }
 
     config.target_os = options.target_os.as_deref().unwrap_or_default().to_vec();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -257,7 +257,7 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
             config.go.package = go_package.to_string();
         }
 
-        if let Some(go_lang) = options.language {
+        if let Some(AvailableLanguage::Go) = options.language {
             assert_go_package_present(&config)?;
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -257,8 +257,11 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
             config.go.package = go_package.to_string();
         }
 
-        if let Some(args::AvailableLanguage::Go) = options.language {
-            assert_go_package_present(&config)?;
+        if matches!(options.language, Some(args::AvailableLanguage::Go)) {
+            anyhow::ensure!(
+                    !config.go.package.is_empty(),
+                   "Please provide a package name in the typeshare.toml or using --go-package <package name>"
+                );
         }
     }
 
@@ -289,14 +292,4 @@ fn check_parse_errors(parsed_crates: &BTreeMap<CrateName, ParsedData>) -> anyhow
     } else {
         Ok(())
     }
-}
-
-#[cfg(feature = "go")]
-fn assert_go_package_present(config: &Config) -> anyhow::Result<()> {
-    if config.go.package.is_empty() {
-        return Err(anyhow!(
-            "Please provide a package name in the typeshare.toml or using --go-package <package name>"
-        ));
-    }
-    Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -257,7 +257,7 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
             config.go.package = go_package.to_string();
         }
 
-        if let Some(crates::args::AvailableLanguage::Go) = options.language {
+        if let Some(args::AvailableLanguage::Go) = options.language {
             assert_go_package_present(&config)?;
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -257,7 +257,7 @@ fn override_configuration(mut config: Config, options: &Args) -> anyhow::Result<
             config.go.package = go_package.to_string();
         }
 
-        if let Some(AvailableLanguage::Go) = options.language {
+        if let Some(crates::args::AvailableLanguage::Go) = options.language {
             assert_go_package_present(&config)?;
         }
     }


### PR DESCRIPTION
As apart of [!184](https://github.com/1Password/typeshare/pull/184) there has been a regression as if you build typeshare with all features and are typesharing not in Golang, the `assert_go_package_is_present` function will still be ran even though your generating for another language

Updated the code to only run the function if the language of the types being converted is Golang.

To test:
Download the latest `typeshare-cli` from main and try generating types for any language but Go without a `--go-package` in the cmd and a package in the `typeshare.toml`.Should error out with:
```
[2024-11-18 15:50:43.169602 -05:00] INFO [typeshare] cli/src/main.rs:49: typeshare started generating types
Error: Please provide a package name in the typeshare.toml or using --go-package <package name>
```
Try the same thing but install from my branch like so:
```
	cargo install --git https://github.com/MOmarMiraj/typeshare --branch omar/fix-go-package --features go
```
and should work as expected.