### PR TITLE
Use typeshare as command name vs typeshare-cli from package

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -16,7 +16,8 @@ pub enum AvailableLanguage {
 #[command(
     version,
     args_conflicts_with_subcommands = true,
-    subcommand_negates_reqs = true
+    subcommand_negates_reqs = true,
+    name = "typeshare"
 )]
 pub struct Args {
     #[command(subcommand)]


### PR DESCRIPTION
When clap was migrated to v4 the help/version would return `typeshare-cli` instead of `typeshare` as the binary name. This PR sets this back to `typeshare`.