### PR TITLE
Use parallel walker instead of rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +245,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -480,26 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,11 +713,11 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "crossbeam",
  "flexi_logger",
  "ignore",
  "log",
  "once_cell",
- "rayon",
  "serde",
  "toml",
  "typeshare-core",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "4.5", features = [
 ] }
 ignore = "0.4"
 once_cell = "1"
-rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 typeshare-core = { path = "../core", version = "=1.13.2" }
@@ -31,3 +30,4 @@ log.workspace = true
 flexi_logger.workspace = true
 anyhow = "1"
 clap_complete = "4.5.32"
+crossbeam = "0.8"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -63,14 +63,14 @@ fn main() -> anyhow::Result<()> {
     let config_file = options.config_file.as_deref();
 
     if options.output.generate_config {
-        let config = override_configuration(Config::default(), &options)?;
-        config::store_config(&config, config_file).context("Failed to create new config file")?;
-        return Ok(());
+        override_configuration(Config::default(), &options)
+            .and_then(|config| config::store_config(&config, config_file))
+            .inspect_err(|err| error!("typeshare failed to create new config file: {err}"))
+    } else {
+        generate_types(config_file, &options).inspect_err(|err| {
+            error!("typeshare failed to generate types: {err}");
+        })
     }
-
-    generate_types(config_file, &options).inspect_err(|err| {
-        error!("Typeshare failed to generate types: {err}");
-    })
 }
 
 fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -77,7 +77,7 @@ fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<
     info!("typeshare started generating types");
 
     let config = config::load_config(config_file).context("Unable to read configuration file")?;
-    let config = override_configuration(config, &options)?;
+    let config = override_configuration(config, options)?;
 
     let directories = options.directories.as_slice();
 
@@ -118,7 +118,7 @@ fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<
 
     let mut parsed_data = parallel_parse(
         &parse_context,
-        walker_builder(directories, &options)?,
+        walker_builder(directories, options)?,
         language_type,
     )?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,27 +140,22 @@ fn main() -> anyhow::Result<()> {
         target_os,
     };
 
-    let crate_parsed_data = parallel_parse(&parse_context, walker_builder, language_type);
+    let parsed_data = parallel_parse(&parse_context, walker_builder, language_type);
 
     // Collect all the types into a map of the file name they
     // belong too and the list of type names. Used for generating
     // imports in generated files.
     let import_candidates = if multi_file {
-        all_types(&crate_parsed_data)
+        all_types(&parsed_data)
     } else {
         HashMap::new()
     };
 
-    check_parse_errors(&crate_parsed_data)?;
+    check_parse_errors(&parsed_data)?;
 
     info!("typeshare started writing generated types");
 
-    write_generated(
-        destination,
-        lang.as_mut(),
-        crate_parsed_data,
-        import_candidates,
-    )?;
+    write_generated(destination, lang.as_mut(), parsed_data, import_candidates)?;
 
     info!("typeshare finished generating types");
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -40,8 +40,8 @@ use crate::{
 
 fn main() -> anyhow::Result<()> {
     flexi_logger::Logger::try_with_env_or_str("info")?
-        .adaptive_format_for_stderr(AdaptiveFormat::Detailed)
-        .adaptive_format_for_stdout(AdaptiveFormat::Detailed)
+        .adaptive_format_for_stderr(AdaptiveFormat::Opt)
+        .adaptive_format_for_stdout(AdaptiveFormat::Opt)
         .start()?;
 
     let options = Args::parse();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -68,6 +68,12 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    generate_types(config_file, &options).inspect_err(|err| {
+        error!("Typeshare failed to generate types: {err}");
+    })
+}
+
+fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<()> {
     info!("typeshare started generating types");
 
     let config = config::load_config(config_file).context("Unable to read configuration file")?;
@@ -114,7 +120,7 @@ fn main() -> anyhow::Result<()> {
         &parse_context,
         walker_builder(directories, &options)?,
         language_type,
-    );
+    )?;
 
     // Collect all the types into a map of the file name they
     // belong too and the list of type names. Used for generating

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -18,7 +18,7 @@ use typeshare_core::{
 };
 
 /// Input data for parsing each source file.
-pub struct ParserInput {
+struct ParserInput {
     /// Rust source file path.
     file_path: PathBuf,
     /// File name source from crate for output.
@@ -80,7 +80,7 @@ pub fn all_types(file_mappings: &mut BTreeMap<CrateName, ParsedData>) -> CrateTy
         )
 }
 
-pub fn parse_input(
+fn parse_input(
     parse_context: &ParseContext,
     parse_input: ParserInput,
 ) -> anyhow::Result<Option<ParsedData>> {

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -129,8 +129,7 @@ fn parse_dir_entry(
         .flatten()
 }
 
-/// Use parallel builder to walk all source directories
-/// in parallel.
+/// Use parallel builder to walk all source directories concurrently.
 pub fn parallel_parse(
     parse_context: &ParseContext,
     walker_builder: WalkBuilder,
@@ -143,6 +142,7 @@ pub fn parallel_parse(
 
         for parsed_data in rx {
             let crate_name = parsed_data.crate_name.clone();
+            // Append each yielded parsed data by its respective crate.
             *crate_parsed_data.entry(crate_name).or_default() += parsed_data;
         }
 
@@ -151,7 +151,6 @@ pub fn parallel_parse(
 
     walker_builder.build_parallel().run(|| {
         let tx = tx.clone();
-        let parse_context = &parse_context;
 
         Box::new(move |direntry_result| match direntry_result {
             Ok(dir_entry) => {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -76,6 +76,8 @@ pub enum ParseError {
     SerdeContentRequired { enum_ident: String },
     #[error("the serde flatten attribute is not currently supported")]
     SerdeFlattenNotAllowed,
+    #[error("IO error: {0}")]
+    IOError(String),
 }
 
 /// Error with it's related data.


### PR DESCRIPTION
The ignore walker we use to walk the list of directories recursively already has built in capabilities for parallel walking. This PR uses that instead of the existing rayon solution.

This PR also refactors the cli code so the main function is broken up into separate functions by separate concerns.