### PR TITLE
Add const support for integer types

### DIFF
--- a/core/data/tests/can_generate_const/input.rs
+++ b/core/data/tests/can_generate_const/input.rs
@@ -1,0 +1,2 @@
+#[typeshare]
+pub const MY_VAR: u32 = 12;

--- a/core/data/tests/can_generate_const/output.go
+++ b/core/data/tests/can_generate_const/output.go
@@ -2,4 +2,4 @@ package proto
 
 import "encoding/json"
 
-const MyVar uint32 = 12;
+const MyVar uint32 = 12

--- a/core/data/tests/can_generate_const/output.go
+++ b/core/data/tests/can_generate_const/output.go
@@ -1,0 +1,5 @@
+package proto
+
+import "encoding/json"
+
+const MyVar uint32 = 12;

--- a/core/data/tests/can_generate_const/output.py
+++ b/core/data/tests/can_generate_const/output.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+
+
+MY_VAR: int = 12

--- a/core/data/tests/can_generate_const/output.ts
+++ b/core/data/tests/can_generate_const/output.ts
@@ -1,0 +1,1 @@
+export const MY_VAR: number = 12;

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -200,7 +200,7 @@ impl Language for Go {
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                 writeln!(
                     w,
-                    "const {} {} = {};",
+                    "const {} {} = {}",
                     c.id.renamed.to_pascal_case(),
                     const_type,
                     val

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use crate::language::SupportedLanguage;
 use crate::parser::ParsedData;
 use crate::rename::RenameExt;
-use crate::rust_types::{RustItem, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{RustConst, RustConstExpr, RustItem, RustTypeFormatError, SpecialRustType};
 use crate::{
     language::Language,
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
@@ -58,6 +58,7 @@ impl Language for Go {
             structs,
             enums,
             aliases,
+            consts,
             ..
         } = data;
 
@@ -66,6 +67,7 @@ impl Language for Go {
             .map(RustItem::Alias)
             .chain(structs.into_iter().map(RustItem::Struct))
             .chain(enums.into_iter().map(RustItem::Enum))
+            .chain(consts.into_iter().map(RustItem::Const))
             .collect::<Vec<_>>();
 
         topsort(&mut items);
@@ -96,6 +98,7 @@ impl Language for Go {
                 RustItem::Enum(e) => self.write_enum(w, e, &types_mapping_to_struct)?,
                 RustItem::Struct(s) => self.write_struct(w, s)?,
                 RustItem::Alias(a) => self.write_type_alias(w, a)?,
+                RustItem::Const(c) => self.write_const(w, c)?,
             }
         }
 
@@ -187,6 +190,10 @@ impl Language for Go {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -192,8 +192,21 @@ impl Language for Go {
         Ok(())
     }
 
-    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
-        todo!()
+    fn write_const(&mut self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        match c.expr {
+            RustConstExpr::Int(val) => {
+                let const_type = self
+                    .format_type(&c.r#type, &[])
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                writeln!(
+                    w,
+                    "const {} {} = {};",
+                    c.id.renamed.to_pascal_case(),
+                    const_type,
+                    val
+                )
+            }
+        }
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -4,7 +4,7 @@ use crate::parser::{remove_dash_from_identifier, DecoratorKind, ParsedData};
 use crate::rust_types::{RustTypeFormatError, SpecialRustType};
 use crate::{
     rename::RenameExt,
-    rust_types::{Id, RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
+    rust_types::{Id, RustConst, RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
 };
 use itertools::Itertools;
 use joinery::JoinableIterator;
@@ -172,6 +172,10 @@ impl Language for Kotlin {
         }
 
         Ok(())
+    }
+
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     parser::{ParseError, ParsedData},
     rust_types::{
-        Id, RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias,
+        Id, RustConst, RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias,
         RustTypeFormatError, SpecialRustType,
     },
     topsort::topsort,
@@ -173,6 +173,7 @@ pub trait Language {
             structs,
             enums,
             aliases,
+            consts,
             ..
         } = data;
 
@@ -181,7 +182,8 @@ pub trait Language {
                 .into_iter()
                 .map(RustItem::Alias)
                 .chain(structs.into_iter().map(RustItem::Struct))
-                .chain(enums.into_iter().map(RustItem::Enum)),
+                .chain(enums.into_iter().map(RustItem::Enum))
+                .chain(consts.into_iter().map(RustItem::Const)),
         );
 
         topsort(&mut items);
@@ -191,6 +193,7 @@ pub trait Language {
                 RustItem::Enum(e) => self.write_enum(writable, e)?,
                 RustItem::Struct(s) => self.write_struct(writable, s)?,
                 RustItem::Alias(a) => self.write_type_alias(writable, a)?,
+                RustItem::Const(c) => self.write_const(writable, c)?,
             }
         }
 
@@ -296,6 +299,15 @@ pub trait Language {
     /// type MyTypeAlias = String;
     /// ```
     fn write_type_alias(&mut self, _w: &mut dyn Write, _t: &RustTypeAlias) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    /// Write a constant variable.
+    /// Example of a constant variable:
+    /// ```
+    /// const ANSWER_TO_EVERYTHING: u32 = 42;
+    /// ```
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
         Ok(())
     }
 

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -3,7 +3,9 @@ use crate::rust_types::{RustEnumShared, RustItem, RustType, RustTypeFormatError,
 use crate::topsort::topsort;
 use crate::{
     language::Language,
-    rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
+    rust_types::{
+        RustConst, RustConstExpr, RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias,
+    },
 };
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -98,6 +100,7 @@ impl Language for Python {
             structs,
             enums,
             aliases,
+            consts,
             ..
         } = data;
 
@@ -106,6 +109,7 @@ impl Language for Python {
             .map(RustItem::Alias)
             .chain(structs.into_iter().map(RustItem::Struct))
             .chain(enums.into_iter().map(RustItem::Enum))
+            .chain(consts.into_iter().map(RustItem::Const))
             .collect::<Vec<_>>();
 
         topsort(&mut items);
@@ -116,6 +120,7 @@ impl Language for Python {
                 RustItem::Enum(e) => self.write_enum(&mut body, &e)?,
                 RustItem::Struct(rs) => self.write_struct(&mut body, &rs)?,
                 RustItem::Alias(t) => self.write_type_alias(&mut body, &t)?,
+                RustItem::Const(c) => self.write_const(&mut body, &c)?,
             };
         }
 
@@ -241,6 +246,10 @@ impl Language for Python {
         self.write_comments(w, true, &ty.comments, 0)?;
 
         Ok(())
+    }
+
+    fn write_const(&mut self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -1,6 +1,7 @@
 use crate::parser::ParsedData;
 use crate::rust_types::{RustEnumShared, RustItem, RustType, RustTypeFormatError, SpecialRustType};
 use crate::topsort::topsort;
+use crate::RenameExt;
 use crate::{
     language::Language,
     rust_types::{
@@ -249,7 +250,20 @@ impl Language for Python {
     }
 
     fn write_const(&mut self, w: &mut dyn Write, c: &RustConst) -> std::io::Result<()> {
-        todo!()
+        match c.expr {
+            RustConstExpr::Int(val) => {
+                let const_type = self
+                    .format_type(&c.r#type, &[])
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                writeln!(
+                    w,
+                    "{}: {} = {};",
+                    c.id.renamed.to_snake_case().to_uppercase(),
+                    const_type,
+                    val
+                )
+            }
+        }
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -257,7 +257,7 @@ impl Language for Python {
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                 writeln!(
                     w,
-                    "{}: {} = {};",
+                    "{}: {} = {}",
                     c.id.renamed.to_snake_case().to_uppercase(),
                     const_type,
                     val

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -1,8 +1,10 @@
 use super::{CrateTypes, Language};
 use crate::language::SupportedLanguage;
 use crate::parser::{remove_dash_from_identifier, ParsedData};
-use crate::rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias};
-use crate::rust_types::{RustType, RustTypeFormatError, SpecialRustType};
+use crate::rust_types::{
+    RustConst, RustEnum, RustEnumVariant, RustField, RustStruct, RustType, RustTypeAlias,
+    RustTypeFormatError, SpecialRustType,
+};
 use itertools::Itertools;
 use joinery::JoinableIterator;
 use lazy_format::lazy_format;
@@ -148,6 +150,10 @@ impl Language for Scala {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -3,8 +3,8 @@ use crate::{
     parser::{remove_dash_from_identifier, DecoratorKind, ParsedData},
     rename::RenameExt,
     rust_types::{
-        DecoratorMap, RustEnum, RustEnumVariant, RustStruct, RustTypeAlias, RustTypeFormatError,
-        SpecialRustType,
+        DecoratorMap, RustConst, RustEnum, RustEnumVariant, RustStruct, RustTypeAlias,
+        RustTypeFormatError, SpecialRustType,
     },
     GenerationError,
 };
@@ -256,6 +256,10 @@ impl Language for Swift {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> std::io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> io::Result<()> {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -1,3 +1,4 @@
+use crate::RenameExt;
 use crate::{
     language::{Language, SupportedLanguage},
     parser::ParsedData,
@@ -120,8 +121,17 @@ impl Language for TypeScript {
         Ok(())
     }
 
-    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> io::Result<()> {
-        todo!()
+    fn write_const(&mut self, w: &mut dyn Write, c: &RustConst) -> io::Result<()> {
+        match c.expr {
+            RustConstExpr::Int(val) => {
+                writeln!(
+                    w,
+                    "export const {} = {};",
+                    c.id.renamed.to_snake_case().to_uppercase(),
+                    val
+                )
+            }
+        }
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> io::Result<()> {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -2,8 +2,8 @@ use crate::{
     language::{Language, SupportedLanguage},
     parser::ParsedData,
     rust_types::{
-        RustEnum, RustEnumVariant, RustField, RustStruct, RustType, RustTypeAlias,
-        RustTypeFormatError, SpecialRustType,
+        RustConst, RustConstExpr, RustEnum, RustEnumVariant, RustField, RustStruct, RustType,
+        RustTypeAlias, RustTypeFormatError, SpecialRustType,
     },
 };
 use itertools::Itertools;
@@ -118,6 +118,10 @@ impl Language for TypeScript {
         )?;
 
         Ok(())
+    }
+
+    fn write_const(&mut self, _w: &mut dyn Write, _c: &RustConst) -> io::Result<()> {
+        todo!()
     }
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> io::Result<()> {

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -124,10 +124,14 @@ impl Language for TypeScript {
     fn write_const(&mut self, w: &mut dyn Write, c: &RustConst) -> io::Result<()> {
         match c.expr {
             RustConstExpr::Int(val) => {
+                let const_type = self
+                    .format_type(&c.r#type, &[])
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                 writeln!(
                     w,
-                    "export const {} = {};",
+                    "export const {}: {} = {};",
                     c.id.renamed.to_snake_case().to_uppercase(),
+                    const_type,
                     val
                 )
             }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -543,11 +543,11 @@ fn parse_const_expr(e: &Expr) -> Result<RustConstExpr, ParseError> {
     struct ExprLitVisitor(pub Option<Result<RustConstExpr, ParseError>>);
     impl Visit<'_> for ExprLitVisitor {
         fn visit_expr_lit(&mut self, el: &ExprLit) {
-            // if self.0.is_some() {
-            //     // should we throw an error instead of silently ignoring a second literal?
-            //     // or would this create false positives?
-            //     return;
-            // }
+            if self.0.is_some() {
+                // should we throw an error instead of silently ignoring a second literal?
+                // or would this create false positives?
+                return;
+            }
             let check_literal_type = || {
                 Ok(match &el.lit {
                     Lit::Int(lit_int) => {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -528,7 +528,8 @@ pub(crate) fn parse_const(c: &ItemConst) -> Result<RustItem, ParseError> {
         | RustType::Special(SpecialRustType::Option(_)) => {
             return Err(ParseError::RustConstTypeInvalid);
         }
-        RustType::Special(_s) => (),
+        RustType::Special(_) => (),
+        RustType::Simple { .. } => (),
         _ => return Err(ParseError::RustConstTypeInvalid),
     };
 
@@ -567,7 +568,7 @@ fn parse_const_expr(e: &Expr) -> Result<RustConstExpr, ParseError> {
     syn::visit::visit_expr(&mut expr_visitor, e);
     expr_visitor
         .0
-        .map_or(Err(ParseError::RustConstTypeInvalid), |v| v)
+        .unwrap_or(Err(ParseError::RustConstTypeInvalid))
 }
 
 // Helpers

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -173,6 +173,7 @@ impl ParsedData {
         self.structs.is_empty()
             && self.enums.is_empty()
             && self.aliases.is_empty()
+            && self.consts.is_empty()
             && self.errors.is_empty()
     }
 }
@@ -542,11 +543,11 @@ fn parse_const_expr(e: &Expr) -> Result<RustConstExpr, ParseError> {
     struct ExprLitVisitor(pub Option<Result<RustConstExpr, ParseError>>);
     impl Visit<'_> for ExprLitVisitor {
         fn visit_expr_lit(&mut self, el: &ExprLit) {
-            if self.0.is_some() {
-                // should we throw an error instead of silently ignoring a second literal?
-                // or would this create false positives?
-                return;
-            }
+            // if self.0.is_some() {
+            //     // should we throw an error instead of silently ignoring a second literal?
+            //     // or would this create false positives?
+            //     return;
+            // }
             let check_literal_type = || {
                 Ok(match &el.lit {
                     Lit::Int(lit_int) => {

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -82,8 +82,11 @@ impl Ord for RustStruct {
 /// ```
 #[derive(Debug, Clone)]
 pub struct RustConst {
+    /// The identifier for the constant.
     pub id: Id,
+    /// The type identifier that this constant is referring to.
     pub r#type: RustType,
+    /// The expression that the constant contains.
     pub expr: RustConstExpr,
 }
 
@@ -97,6 +100,7 @@ impl PartialEq for RustConst {
 /// boundary.
 #[derive(Debug, Clone)]
 pub enum RustConstExpr {
+    /// Expression represents an integer.
     Int(i128),
 }
 

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -74,6 +74,32 @@ impl Ord for RustStruct {
     }
 }
 
+/// Rust const variable.
+///
+/// Typeshare can only handle numeric and string constants.
+/// ```
+/// pub const MY_CONST: &str = "constant value";
+/// ```
+#[derive(Debug, Clone)]
+pub struct RustConst {
+    pub id: Id,
+    pub r#type: RustType,
+    pub expr: RustConstExpr,
+}
+
+impl PartialEq for RustConst {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.original == other.id.original
+    }
+}
+
+/// A constant expression that can be shared via a constant variable across the typeshare
+/// boundary.
+#[derive(Debug, Clone)]
+pub enum RustConstExpr {
+    Int(i128),
+}
+
 /// Rust type alias.
 /// ```
 /// pub struct MasterPassword(String);
@@ -698,4 +724,6 @@ pub enum RustItem {
     Enum(RustEnum),
     /// A `type` definition or newtype struct.
     Alias(RustTypeAlias),
+    /// A `const` definition
+    Const(RustConst),
 }

--- a/core/src/topsort.rs
+++ b/core/src/topsort.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::rust_types::{
-    RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias, SpecialRustType,
+    RustConst, RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias,
+    SpecialRustType,
 };
 
 fn get_dependencies_from_type(
@@ -120,6 +121,18 @@ fn get_type_alias_dependencies(
     }
 }
 
+fn get_const_dependencies(
+    c: &RustConst,
+    types: &HashMap<String, &RustItem>,
+    res: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    if seen.insert(c.id.original.to_string()) {
+        get_dependencies_from_type(&c.r#type, types, res, seen);
+        seen.remove(&c.id.original.to_string());
+    }
+}
+
 fn get_dependencies(
     thing: &RustItem,
     types: &HashMap<String, &RustItem>,
@@ -130,6 +143,7 @@ fn get_dependencies(
         RustItem::Enum(en) => get_enum_dependencies(en, types, res, seen),
         RustItem::Struct(strct) => get_struct_dependencies(strct, types, res, seen),
         RustItem::Alias(alias) => get_type_alias_dependencies(alias, types, res, seen),
+        RustItem::Const(c) => get_const_dependencies(c, types, res, seen),
     }
 }
 
@@ -194,6 +208,7 @@ pub(crate) fn topsort(things: &mut [RustItem]) {
             },
             RustItem::Struct(strct) => strct.id.original.clone(),
             RustItem::Alias(ta) => ta.id.original.clone(),
+            RustItem::Const(c) => c.id.original.clone(),
         };
         (id, thing)
     }));

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -487,6 +487,7 @@ tests! {
         scala,
         typescript
     ];
+    can_generate_const: [typescript, go, python];
     can_generate_slice_of_user_type: [swift, kotlin, scala, typescript, go, python];
     can_generate_readonly_fields: [
         typescript


### PR DESCRIPTION
This PR contains the functionality to parse Rust integer constants and generate them into the following languages:
- Go
- Typescript
- Python

The foundational pieces can easily be extended to other constant types (e.g. Boolean, Float and String). However, additional guidance and support might be needed to ensure it works as expected for the other types as well.

This is heavily inspired from #57. It was adapted to the latest version from `main` and added the code generation snippets for Go, Typescript and Python.

Relates: #44