### PR TITLE
Make changes required for Go translation to support generics

### DIFF
--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -106,6 +106,10 @@ impl Language for Go {
         &self.type_mappings
     }
 
+    fn format_generic_parameters(&mut self, parameters: Vec<String>) -> String {
+        format!("[{}]", parameters.join(", "))
+    }
+
     fn format_special_type(
         &mut self,
         special_ty: &SpecialRustType,
@@ -189,8 +193,11 @@ impl Language for Go {
         write_comments(w, 0, &rs.comments)?;
         writeln!(
             w,
-            "type {} struct {{",
-            self.acronyms_to_uppercase(&rs.id.renamed)
+            "type {}{} struct {{",
+            self.acronyms_to_uppercase(&rs.id.renamed),
+            (!rs.generic_types.is_empty())
+                .then(|| format!("[{}]", rs.generic_types.iter().map(|ty| format!("{} any", ty)).collect::<Vec<String>>().join(", ")))
+                .unwrap_or_default()
         )?;
 
         rs.fields

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -191,6 +191,7 @@ impl Language for Go {
 
     fn write_struct(&mut self, w: &mut dyn Write, rs: &RustStruct) -> std::io::Result<()> {
         write_comments(w, 0, &rs.comments)?;
+        // TODO: Support generic bounds: https://github.com/1Password/typeshare/issues/222
         writeln!(
             w,
             "type {}{} struct {{",

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -196,7 +196,14 @@ impl Language for Go {
             "type {}{} struct {{",
             self.acronyms_to_uppercase(&rs.id.renamed),
             (!rs.generic_types.is_empty())
-                .then(|| format!("[{}]", rs.generic_types.iter().map(|ty| format!("{} any", ty)).collect::<Vec<String>>().join(", ")))
+                .then(|| format!(
+                    "[{}]",
+                    rs.generic_types
+                        .iter()
+                        .map(|ty| format!("{} any", ty))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                ))
                 .unwrap_or_default()
         )?;
 


### PR DESCRIPTION
## 📰 Overview
The current TypeShare implementation we're using doesn't support Struct Generics in Go.


## 🚀 Acceptance Criteria
<!-- What does done look like? -->

- [x] The following rust snippet should translate to the following Go snippet:
```Rust
#[typeshare]
#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
#[serde(rename_all = "camelCase")]
pub(crate) struct ItemsGetAllResponse {
    pub(crate) individual_responses: Vec<IndividualResponse<Item, ItemsGetAllError>>,
}

#[typeshare]
#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
#[serde(rename_all = "camelCase")]
pub(crate) struct IndividualResponse<T, E> {
    pub(crate) content: Option<T>,
    pub(crate) error: Option<E>,
}
```

```Golang
type IndividualResponse[T any, E any] struct {
	Content *T `json:"content,omitempty"`
	Error *E `json:"error,omitempty"`
}

type ItemsGetAllResponse struct {
	IndividualResponses []IndividualResponse[Item, ItemsGetAllError] `json:"individualResponses"`
}
```

while currently it translates to

```
type IndividualResponse struct {
	Content *T `json:"content,omitempty"`
	Error *E `json:"error,omitempty"`
}

type ItemsGetAllResponse struct {
	IndividualResponses []IndividualResponse<Item, ItemsGetAllError> `json:"individualResponses"`
}
```