### PR TITLE
Bump hashbrown version to resolve security alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"


### PR DESCRIPTION
Resolves https://github.com/1Password/typeshare/security/dependabot/4

Info
-----
* Per the dependabot alert, hashbrown version `0.15.0` has a potential security issue, which was fixed in `0.15.1` and above.
* `hashbrown` is purely a transitive dependency, so there's no change needed to our direct dependencies.

Changes
-----
* Ran `cargo update` to bump the version of `hashbrown` used in our `Cargo.lock` file

Tested
-----
* Typeshare still builds and passes tests after the version bump