### PR TITLE
Fix writing enum values in Go

### DIFF
--- a/core/data/tests/anonymous_struct_with_rename/output.go
+++ b/core/data/tests/anonymous_struct_with_rename/output.go
@@ -20,9 +20,9 @@ type AnonymousStructWithRenameKebabCaseInner struct {
 }
 type AnonymousStructWithRenameTypes string
 const (
-	AnonymousStructWithRenameTypeVariantList AnonymousStructWithRenameTypes = "List"
-	AnonymousStructWithRenameTypeVariantLongFieldNames AnonymousStructWithRenameTypes = "LongFieldNames"
-	AnonymousStructWithRenameTypeVariantKebabCase AnonymousStructWithRenameTypes = "KebabCase"
+	AnonymousStructWithRenameTypeVariantList AnonymousStructWithRenameTypes = "list"
+	AnonymousStructWithRenameTypeVariantLongFieldNames AnonymousStructWithRenameTypes = "longFieldNames"
+	AnonymousStructWithRenameTypeVariantKebabCase AnonymousStructWithRenameTypes = "kebabCase"
 )
 type AnonymousStructWithRename struct{ 
 	Type AnonymousStructWithRenameTypes `json:"type"`

--- a/core/data/tests/can_generate_algebraic_enum/output.go
+++ b/core/data/tests/can_generate_algebraic_enum/output.go
@@ -121,11 +121,11 @@ func NewAdvancedColorsTypeVariantReallyCoolType(content *ItemDetailsFieldValue) 
 type AdvancedColors2Types string
 const (
 	// This is a case comment
-	AdvancedColors2TypeVariantString AdvancedColors2Types = "String"
-	AdvancedColors2TypeVariantNumber AdvancedColors2Types = "Number"
-	AdvancedColors2TypeVariantNumberArray AdvancedColors2Types = "NumberArray"
+	AdvancedColors2TypeVariantString AdvancedColors2Types = "string"
+	AdvancedColors2TypeVariantNumber AdvancedColors2Types = "number"
+	AdvancedColors2TypeVariantNumberArray AdvancedColors2Types = "number-array"
 	// Comment on the last element
-	AdvancedColors2TypeVariantReallyCoolType AdvancedColors2Types = "ReallyCoolType"
+	AdvancedColors2TypeVariantReallyCoolType AdvancedColors2Types = "really-cool-type"
 )
 type AdvancedColors2 struct{ 
 	Type AdvancedColors2Types `json:"type"`

--- a/core/data/tests/can_handle_unit_type/output.go
+++ b/core/data/tests/can_handle_unit_type/output.go
@@ -9,7 +9,7 @@ type StructHasVoidType struct {
 // This enum has a variant associated with unit data
 type EnumHasVoidTypeTypes string
 const (
-	EnumHasVoidTypeTypeVariantHasAUnit EnumHasVoidTypeTypes = "HasAUnit"
+	EnumHasVoidTypeTypeVariantHasAUnit EnumHasVoidTypeTypes = "hasAUnit"
 )
 type EnumHasVoidType struct{ 
 	Type EnumHasVoidTypeTypes `json:"type"`

--- a/core/data/tests/recursive_enum_decorator/output.go
+++ b/core/data/tests/recursive_enum_decorator/output.go
@@ -12,9 +12,9 @@ type MoreOptionsBuiltInner struct {
 }
 type MoreOptionsTypes string
 const (
-	MoreOptionsTypeVariantNews MoreOptionsTypes = "News"
-	MoreOptionsTypeVariantExactly MoreOptionsTypes = "Exactly"
-	MoreOptionsTypeVariantBuilt MoreOptionsTypes = "Built"
+	MoreOptionsTypeVariantNews MoreOptionsTypes = "news"
+	MoreOptionsTypeVariantExactly MoreOptionsTypes = "exactly"
+	MoreOptionsTypeVariantBuilt MoreOptionsTypes = "built"
 )
 type MoreOptions struct{ 
 	Type MoreOptionsTypes `json:"type"`
@@ -94,9 +94,9 @@ func NewMoreOptionsTypeVariantBuilt(content *MoreOptionsBuiltInner) MoreOptions 
 
 type OptionsTypes string
 const (
-	OptionsTypeVariantRed OptionsTypes = "Red"
-	OptionsTypeVariantBanana OptionsTypes = "Banana"
-	OptionsTypeVariantVermont OptionsTypes = "Vermont"
+	OptionsTypeVariantRed OptionsTypes = "red"
+	OptionsTypeVariantBanana OptionsTypes = "banana"
+	OptionsTypeVariantVermont OptionsTypes = "vermont"
 )
 type Options struct{ 
 	Type OptionsTypes `json:"type"`

--- a/core/data/tests/test_algebraic_enum_case_name_support/output.go
+++ b/core/data/tests/test_algebraic_enum_case_name_support/output.go
@@ -6,10 +6,10 @@ type ItemDetailsFieldValue struct {
 }
 type AdvancedColorsTypes string
 const (
-	AdvancedColorsTypeVariantString AdvancedColorsTypes = "String"
-	AdvancedColorsTypeVariantNumber AdvancedColorsTypes = "Number"
-	AdvancedColorsTypeVariantNumberArray AdvancedColorsTypes = "NumberArray"
-	AdvancedColorsTypeVariantReallyCoolType AdvancedColorsTypes = "ReallyCoolType"
+	AdvancedColorsTypeVariantString AdvancedColorsTypes = "string"
+	AdvancedColorsTypeVariantNumber AdvancedColorsTypes = "number"
+	AdvancedColorsTypeVariantNumberArray AdvancedColorsTypes = "number-array"
+	AdvancedColorsTypeVariantReallyCoolType AdvancedColorsTypes = "reallyCoolType"
 )
 type AdvancedColors struct{ 
 	Type AdvancedColorsTypes `json:"type"`

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -413,7 +413,7 @@ impl Go {
                         "\t{} {} = {:?}",
                         variant_type_const,
                         variant_key_type,
-                        &v.shared().id.original
+                        &v.shared().id.renamed
                     )?;
                 }
 


### PR DESCRIPTION
## Summary

This PR fixes generating Algebraic Rust Enums in Go to properly set the constant values according to the serde configuration for that enum.

## Background

For Algebraic Rust Enums, when generating them in Go, the values of the constants were the original name of the enum variant instead of the renamed one, which takes into consideration the serde attributes. Because of that, it could happen that in such enums the JSON unmarshalling will fail due to not having any content to process. That was caused by the match case not hitting any variant.