### PR TITLE
Fix Bug in JS and Python Typesharing Custom Types

### DIFF
--- a/core/data/tests/test_byte_translation/input.rs
+++ b/core/data/tests/test_byte_translation/input.rs
@@ -2,4 +2,5 @@
 #[serde(rename_all = "camelCase")]
 pub struct Foo {
     pub this_is_bits: Vec<u8>,
+    pub this_is_redundant: Vec<u8>
 }

--- a/core/data/tests/test_byte_translation/output.go
+++ b/core/data/tests/test_byte_translation/output.go
@@ -4,4 +4,5 @@ import "encoding/json"
 
 type Foo struct {
 	ThisIsBits []byte `json:"thisIsBits"`
+	ThisIsRedundant []byte `json:"thisIsRedundant"`
 }

--- a/core/data/tests/test_byte_translation/output.py
+++ b/core/data/tests/test_byte_translation/output.py
@@ -9,11 +9,11 @@ def serialize_binary_data(value: bytes) -> list[int]:
 
 def deserialize_binary_data(value):
      if isinstance(value, list):
-         if all(isinstance(x, int) and 0 <= x <= 255 for x in value) & len(value) > 0:
-             return bytes(value)
+         if all(isinstance(x, int) and 0 <= x <= 255 for x in value):
+            return bytes(value)
          raise ValueError("All elements must be integers in the range 0-255 (u8).")
      elif isinstance(value, bytes):
-             return value
+            return value
      raise TypeError("Content must be a list of integers (0-255) or bytes.")
 
 class Foo(BaseModel):

--- a/core/data/tests/test_byte_translation/output.py
+++ b/core/data/tests/test_byte_translation/output.py
@@ -9,7 +9,7 @@ def serialize_binary_data(value: bytes) -> list[int]:
 
 def deserialize_binary_data(value):
      if isinstance(value, list):
-         if all(isinstance(x, int) and 0 <= x <= 255 for x in value):
+         if all(isinstance(x, int) and 0 <= x <= 255 for x in value) & len(value) > 0:
              return bytes(value)
          raise ValueError("All elements must be integers in the range 0-255 (u8).")
      elif isinstance(value, bytes):
@@ -20,4 +20,5 @@ class Foo(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     this_is_bits: Annotated[bytes, BeforeValidator(deserialize_binary_data), PlainSerializer(serialize_binary_data)] = Field(alias="thisIsBits")
+    this_is_redundant: Annotated[bytes, BeforeValidator(deserialize_binary_data), PlainSerializer(serialize_binary_data)] = Field(alias="thisIsRedundant")
 

--- a/core/data/tests/test_byte_translation/output.ts
+++ b/core/data/tests/test_byte_translation/output.ts
@@ -1,11 +1,12 @@
 export interface Foo {
 	thisIsBits: Uint8Array;
+	thisIsRedundant: Uint8Array;
 }
 
 export function ReviverFunc(key: string, value: unknown): unknown {
-    if (Array.isArray(value) && value.every(v => Number.isInteger(v) && v >= 0 && v <= 255)) {
-                    return new Uint8Array(value);
-                }
+    if (Array.isArray(value) && value.every(v => Number.isInteger(v) && v >= 0 && v <= 255) && value.length > 0)  {
+        return new Uint8Array(value);
+    }
     return value;
 }
 

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -91,8 +91,8 @@ pub struct Python {
     /// Whether or not to exclude the version header that normally appears at the top of generated code.
     /// If you aren't generating a snapshot test, this setting can just be left as a default (false)
     pub no_version_header: bool,
-    /// Carries the content of the custom serializer and deserializer functions if required
-    pub custom_json_translation_functions: HashSet<String>,
+    /// Carries the unique set of types for custom json translation
+    pub types_for_custom_json_translation: HashSet<String>,
 }
 
 impl Language for Python {
@@ -138,24 +138,22 @@ impl Language for Python {
 
         self.write_all_imports(w)?;
 
-        if !self.custom_json_translation_functions.is_empty() {
-            self.custom_json_translation_functions
-                .iter()
-                .filter_map(|py_type| json_translation_for_type(py_type))
-                .map(|custom_translation_functions| {
-                    format!(
-                        r#"{}
+        self.types_for_custom_json_translation
+            .iter()
+            .filter_map(|py_type| json_translation_for_type(py_type))
+            .map(|custom_translation_functions| {
+                format!(
+                    r#"{}
 
 {}"#,
-                        custom_translation_functions.serialization_content,
-                        custom_translation_functions.deserialization_content
-                    )
-                })
-                .try_for_each(|custom_translation_function| -> std::io::Result<()> {
-                    writeln!(w, "{custom_translation_function}")?;
-                    writeln!(w)
-                })?;
-        }
+                    custom_translation_functions.serialization_content,
+                    custom_translation_functions.deserialization_content
+                )
+            })
+            .try_for_each(|custom_translation_function| -> std::io::Result<()> {
+                writeln!(w, "{custom_translation_function}")?;
+                writeln!(w)
+            })?;
 
         w.write_all(&body)
     }
@@ -205,7 +203,7 @@ impl Language for Python {
     ) -> Result<String, RustTypeFormatError> {
         if let Some(mapped) = self.type_mappings.get(&special_ty.to_string()) {
             if json_translation_for_type(mapped).is_some() {
-                self.custom_json_translation_functions
+                self.types_for_custom_json_translation
                     .insert(mapped.to_string());
             }
             return Ok(mapped.to_owned());
@@ -761,11 +759,11 @@ fn json_translation_for_type(python_type: &str) -> Option<CustomJsonTranslationF
             deserialization_name: "deserialize_binary_data".to_owned(),
             deserialization_content: r#"def deserialize_binary_data(value):
      if isinstance(value, list):
-         if all(isinstance(x, int) and 0 <= x <= 255 for x in value) & len(value) > 0:
-             return bytes(value)
+         if all(isinstance(x, int) and 0 <= x <= 255 for x in value):
+            return bytes(value)
          raise ValueError("All elements must be integers in the range 0-255 (u8).")
      elif isinstance(value, bytes):
-             return value
+            return value
      raise TypeError("Content must be a list of integers (0-255) or bytes.")"#
                 .to_owned(),
         },

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -137,7 +137,7 @@ impl Language for Python {
         }
 
         self.write_all_imports(w)?;
-        
+
         if !self.custom_json_translation_functions.is_empty() {
             self.custom_json_translation_functions
                 .iter()

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -25,8 +25,8 @@ pub struct TypeScript {
     /// Whether or not to exclude the version header that normally appears at the top of generated code.
     /// If you aren't generating a snapshot test, this setting can just be left as a default (false)
     pub no_version_header: bool,
-    /// Carries the content of the custom reviver/replacer content if needed.
-    pub custom_json_translation_functions: HashSet<String>,
+    /// Carries the unique set of types for custom json translation
+    pub types_for_custom_json_translation: HashSet<String>,
 }
 
 #[derive(Clone)]
@@ -41,9 +41,9 @@ impl Language for TypeScript {
     }
 
     fn end_file(&mut self, w: &mut dyn Write) -> std::io::Result<()> {
-        if !self.custom_json_translation_functions.is_empty() {
+        if !self.types_for_custom_json_translation.is_empty() {
             let custom_translation_content: Vec<CustomJsonTranslationContent> = self
-                .custom_json_translation_functions
+                .types_for_custom_json_translation
                 .iter()
                 .filter_map(|ts_type| custom_translations(ts_type))
                 .collect();
@@ -77,7 +77,7 @@ export function ReplacerFunc(key: string, value: unknown): unknown {{
     ) -> Result<String, RustTypeFormatError> {
         if let Some(mapped) = self.type_mappings.get(&special_ty.to_string()) {
             if custom_translations(mapped).is_some() {
-                self.custom_json_translation_functions
+                self.types_for_custom_json_translation
                     .insert(mapped.to_string());
             }
             return Ok(mapped.to_owned());


### PR DESCRIPTION
With #230 , we added custom translations for python and typescript which is used in the SDKs. Currently in main this will duplicate the serialization and deserialization for every type even if its the same. Also for the `deserialization` of bytes, we added an additional check to ensure that the length of the array is 0 so we don't convert empty arrays to the byte type.