### PR TITLE
Update Reviver/Replacer functions in TS typeshare

### DIFF
--- a/core/data/tests/test_byte_translation/output.ts
+++ b/core/data/tests/test_byte_translation/output.ts
@@ -3,16 +3,22 @@ export interface Foo {
 	thisIsRedundant: Uint8Array;
 }
 
-export function ReviverFunc(key: string, value: unknown): unknown {
+/**
+ * Custom JSON reviver and replacer functions for dynamic data transformation
+ * ReviverFunc is used during JSON parsing to detect and transform specific data structures
+ * ReplacerFunc is used during JSON serialization to modify certain values before stringifying.
+ * These functions allow for flexible encoding and decoding of data, ensuring that complex types are properly handled when converting between TS objects and JSON
+ */
+export const ReviverFunc = (key: string, value: unknown): unknown => {
     if (Array.isArray(value) && value.every(v => Number.isInteger(v) && v >= 0 && v <= 255) && value.length > 0)  {
         return new Uint8Array(value);
     }
     return value;
-}
+};
 
-export function ReplacerFunc(key: string, value: unknown): unknown {
+export const ReplacerFunc = (key: string, value: unknown): unknown => {
     if (value instanceof Uint8Array) {
         return Array.from(value);
     }
     return value;
-}
+};

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -47,17 +47,22 @@ impl Language for TypeScript {
                 .iter()
                 .filter_map(|ts_type| custom_translations(ts_type))
                 .collect();
+            self.write_comments(w, 0, &["Custom JSON reviver and replacer functions for dynamic data transformation".to_owned(),
+            "ReviverFunc is used during JSON parsing to detect and transform specific data structures".to_owned(),
+            "ReplacerFunc is used during JSON serialization to modify certain values before stringifying.".to_owned(),
+            "These functions allow for flexible encoding and decoding of data, ensuring that complex types are properly handled when converting between TS objects and JSON".to_owned()])?;
+            
             return writeln!(
                 w,
-                r#"export function ReviverFunc(key: string, value: unknown): unknown {{
+                r#"export const ReviverFunc = (key: string, value: unknown): unknown => {{
     {}
     return value;
-}}
+}};
 
-export function ReplacerFunc(key: string, value: unknown): unknown {{
+export const ReplacerFunc = (key: string, value: unknown): unknown => {{
     {}
     return value;
-}}"#,
+}};"#,
                 custom_translation_content
                     .iter()
                     .map(|custom_json_translation| custom_json_translation.reviver.clone())

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -51,7 +51,7 @@ impl Language for TypeScript {
             "ReviverFunc is used during JSON parsing to detect and transform specific data structures".to_owned(),
             "ReplacerFunc is used during JSON serialization to modify certain values before stringifying.".to_owned(),
             "These functions allow for flexible encoding and decoding of data, ensuring that complex types are properly handled when converting between TS objects and JSON".to_owned()])?;
-            
+
             return writeln!(
                 w,
                 r#"export const ReviverFunc = (key: string, value: unknown): unknown => {{


### PR DESCRIPTION
This PR will convert the reviver/replacer functions to const + `=>` as per these are preferred over named functions (eslint recommendation). Also add comments explaining what these two functions are used for.