### PR TITLE
Fixed conditional writing of Codable.swift

### DIFF
--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -790,12 +790,12 @@ impl Swift {
             decs.push(CODABLE);
         }
 
-        format!("\n/// () isn't codable, so we use this instead to represent Rust's unit type\npublic struct CodableVoid: {} {{}}", decs.join(", "))
+        format!("\n/// () isn't codable, so we use this instead to represent Rust's unit type\npublic struct CodableVoid: {} {{}}\n", decs.join(", "))
     }
 
     /// Write the `CodableVoid` type.
     fn write_codable(&self, w: &mut dyn Write, output_string: &str) -> io::Result<()> {
-        writeln!(w, "{}", output_string)
+        write!(w, "{}", output_string)
     }
 
     /// Build the generic constraints output. This checks for the `swiftGenericConstraints` typeshare attribute and combines


### PR DESCRIPTION
Moved location of newline character generation so that the file contents diff check inside write_codable_file will work as expected.

The Codable.swift file in only supposed to be written to disk if it has changed. Currently, the Codeable.swift file is always being written to disk. This causes problems with Xcode previews. When the typeshare script is run as part of an Xcode preview build, Xcode detects a file change (Codeable.swift) and restarts the compilation in an endless loop.

A previous fix to this bug was made/attempted here: https://github.com/1Password/typeshare/pull/205.