### PR TITLE
Add support for Kotlin custom serializers

### DIFF
--- a/app/cli/snapshot-tests/custom_serializer/input.rs
+++ b/app/cli/snapshot-tests/custom_serializer/input.rs
@@ -1,0 +1,16 @@
+#[typeshare(kotlin = "Serializer(CustomSerializer)")]
+pub struct BestHockeyTeams {
+    PittsburghPenguins: u32,
+    Lies: String,
+}
+
+#[typeshare(kotlin = "Serializer(CustomSerializer)")]
+#[serde(tag = "type", content = "content")]
+pub enum Phrase {
+    ScanSetupCode,
+    TotpSecondsRemaining(String),
+    NestedAnonymousStruct {
+        nested_field: String,
+        another_nested_field: String
+    }
+}

--- a/app/cli/snapshot-tests/custom_serializer/output.kt
+++ b/app/cli/snapshot-tests/custom_serializer/output.kt
@@ -1,0 +1,31 @@
+package com.agilebits.onepassword
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+@Serializable(with = CustomSerializer::class)
+data class BestHockeyTeams (
+	val PittsburghPenguins: UInt,
+	val Lies: String
+)
+
+/// Generated type representing the anonymous struct variant `NestedAnonymousStruct` of the `Phrase` Rust enum
+@Serializable
+data class PhraseNestedAnonymousStructInner (
+	val nested_field: String,
+	val another_nested_field: String
+)
+
+@Serializable(with = CustomSerializer::class)
+sealed class Phrase {
+	@Serializable
+	@SerialName("ScanSetupCode")
+	object ScanSetupCode: Phrase()
+	@Serializable
+	@SerialName("TotpSecondsRemaining")
+	data class TotpSecondsRemaining(val content: String): Phrase()
+	@Serializable
+	@SerialName("NestedAnonymousStruct")
+	data class NestedAnonymousStruct(val content: PhraseNestedAnonymousStructInner): Phrase()
+}
+

--- a/app/engine/src/args.rs
+++ b/app/engine/src/args.rs
@@ -133,7 +133,7 @@ pub fn add_personalizations(
     command: clap::Command,
     personalizations: PersonalizeClap,
 ) -> clap::Command {
-    let command = command.arg(
+    let command = command.disable_version_flag(true).arg(
         clap::Arg::new("version")
             .short('V')
             .long("version")

--- a/app/engine/src/args.rs
+++ b/app/engine/src/args.rs
@@ -148,12 +148,10 @@ pub fn add_personalizations(
         None => command,
     };
 
-    let command = match personalizations.about {
+    match personalizations.about {
         Some(about) => command.about(about),
         None => command,
-    };
-
-    command
+    }
 }
 
 /// Add a `--lang` argument to the command. This argument will be optional if

--- a/app/engine/src/args.rs
+++ b/app/engine/src/args.rs
@@ -133,13 +133,6 @@ pub fn add_personalizations(
     command: clap::Command,
     personalizations: PersonalizeClap,
 ) -> clap::Command {
-    let command = command.disable_version_flag(true).arg(
-        clap::Arg::new("version")
-            .short('V')
-            .long("version")
-            .action(clap::ArgAction::Version),
-    );
-
     let command = match personalizations.name {
         Some(name) => command.name(name),
         None => command,

--- a/app/engine/src/config.rs
+++ b/app/engine/src/config.rs
@@ -170,8 +170,8 @@ pub fn load_language_config<'a, 'config, L: Language<'config>>(
     spec: &'a CliArgsSet,
 ) -> anyhow::Result<L::Config> {
     L::Config::deserialize(ConfigDeserializer::new(
-        &config_file_entry,
-        &cli_matches,
+        config_file_entry,
+        cli_matches,
         spec,
     ))
     .context("error deserializing config")

--- a/app/engine/src/driver.rs
+++ b/app/engine/src/driver.rs
@@ -152,7 +152,7 @@ fn execute_typeshare_for_language<'config, 'a, L: Language<'config>>(
 ) -> anyhow::Result<()> {
     let name = L::NAME;
 
-    let config = load_language_config_from_file_and_args::<L>(&config, &args, meta)
+    let config = load_language_config_from_file_and_args::<L>(config, args, meta)
         .with_context(|| format!("failed to load configuration for language {name}"))?;
 
     let language_implementation = <L>::new_from_config(config)
@@ -287,7 +287,7 @@ where
         .expect("clap should guarantee that --lang is provided");
 
     Helper::LanguageSet::execute_typeshare_for_language(
-        &language,
+        language,
         &config,
         &args,
         &language_metas,

--- a/app/engine/src/parser.rs
+++ b/app/engine/src/parser.rs
@@ -377,6 +377,7 @@ pub(crate) fn parse_struct(
                 fields,
                 comments: parse_comment_attrs(&s.attrs),
                 decorators,
+                is_anonymous: false,
             })
         }
         // Tuple structs
@@ -407,6 +408,7 @@ pub(crate) fn parse_struct(
             fields: vec![],
             comments: parse_comment_attrs(&s.attrs),
             decorators,
+            is_anonymous: false,
         }),
     })
 }

--- a/app/engine/src/parser.rs
+++ b/app/engine/src/parser.rs
@@ -329,7 +329,7 @@ pub(crate) fn parse_struct(
     if let Some(ty) = get_serialized_as_type(&decorators) {
         return Ok(RustItem::Alias(RustTypeAlias {
             id: get_ident(Some(&s.ident), &s.attrs, None),
-            ty: parse_rust_type_from_string(&ty)?,
+            ty: parse_rust_type_from_string(ty)?,
             comments: parse_comment_attrs(&s.attrs),
             generic_types,
             decorators,
@@ -351,7 +351,7 @@ pub(crate) fn parse_struct(
                     let decorators = get_decorators(&f.attrs);
 
                     let ty = match get_serialized_as_type(&decorators) {
-                        Some(ty) => parse_rust_type_from_string(&ty)?,
+                        Some(ty) => parse_rust_type_from_string(ty)?,
                         None => parse_rust_type(&f.ty)?,
                     };
 
@@ -389,13 +389,13 @@ pub(crate) fn parse_struct(
             let field_decorators = get_decorators(&field.attrs);
 
             let ty = match get_serialized_as_type(&field_decorators) {
-                Some(ty) => parse_rust_type_from_string(&ty)?,
+                Some(ty) => parse_rust_type_from_string(ty)?,
                 None => parse_rust_type(&field.ty)?,
             };
 
             RustItem::Alias(RustTypeAlias {
                 id: get_ident(Some(&s.ident), &s.attrs, None),
-                ty: ty,
+                ty,
                 comments: parse_comment_attrs(&s.attrs),
                 generic_types,
                 decorators,
@@ -437,7 +437,7 @@ pub(crate) fn parse_enum(e: &ItemEnum, valid_os: Option<&[&str]>) -> Result<Rust
     if let Some(ty) = get_serialized_as_type(&decorators) {
         return Ok(RustItem::Alias(RustTypeAlias {
             id: get_ident(Some(&e.ident), &e.attrs, None),
-            ty: parse_rust_type_from_string(&ty)?,
+            ty: parse_rust_type_from_string(ty)?,
             comments: parse_comment_attrs(&e.attrs),
             generic_types,
             decorators,
@@ -569,7 +569,7 @@ fn parse_enum_variant(
             let decorators = get_decorators(&field.attrs);
 
             let ty = match get_serialized_as_type(&decorators) {
-                Some(ty) => parse_rust_type_from_string(&ty)?,
+                Some(ty) => parse_rust_type_from_string(ty)?,
                 None => parse_rust_type(&field.ty)?,
             };
 
@@ -588,7 +588,7 @@ fn parse_enum_variant(
                     let decorators = get_decorators(&f.attrs);
 
                     let field_type = match get_serialized_as_type(&decorators) {
-                        Some(ty) => parse_rust_type_from_string(&ty)?,
+                        Some(ty) => parse_rust_type_from_string(ty)?,
                         None => parse_rust_type(&f.ty)?,
                     };
 
@@ -618,7 +618,7 @@ pub(crate) fn parse_type_alias(t: &ItemType) -> Result<RustItem, ParseError> {
     let decorators = get_decorators(&t.attrs);
 
     let ty = match get_serialized_as_type(&decorators) {
-        Some(ty) => parse_rust_type_from_string(&ty)?,
+        Some(ty) => parse_rust_type_from_string(ty)?,
         None => parse_rust_type(&t.ty)?,
     };
 
@@ -967,10 +967,8 @@ mod test_get_decorators {
 
     fn parse_attr(input: &str) -> Vec<Attribute> {
         let tokens = TokenStream::from_str(input).expect("failed to create token stream");
-        let attr =
-            Parser::parse2(Attribute::parse_outer, tokens).expect("failed to parse attribute");
 
-        attr
+        Parser::parse2(Attribute::parse_outer, tokens).expect("failed to parse attribute")
     }
 
     #[test]

--- a/app/engine/src/target_os.rs
+++ b/app/engine/src/target_os.rs
@@ -122,7 +122,7 @@ pub fn target_os_good(config: &Cfg, valid: &[&str]) -> bool {
         let outcome = config.test(&|pred| {
             if pred.key == "target_os" {
                 if let Some(value) = pred.value.as_deref() {
-                    return match valid.contains(&value) {
+                    return match valid.contains(value) {
                         true => Outcome::True,
                         false => Outcome::False,
                     };

--- a/app/engine/src/topsort.rs
+++ b/app/engine/src/topsort.rs
@@ -13,14 +13,14 @@ fn get_dependencies_from_type<'a>(
     match tp {
         RustType::Generic { id, parameters } => {
             if let Some(&tp) = types.get(id) {
-                if seen.insert(&id) {
-                    res.push(&id);
+                if seen.insert(id) {
+                    res.push(id);
                     get_dependencies(tp, types, res, seen);
                     for parameter in parameters {
                         if let Some(id) = parameter.id() {
                             if let Some(&tp) = types.get(id) {
-                                if seen.insert(&id) {
-                                    res.push(&id);
+                                if seen.insert(id) {
+                                    res.push(id);
                                     get_dependencies(tp, types, res, seen);
                                     seen.remove(&id.clone());
                                 }
@@ -36,7 +36,7 @@ fn get_dependencies_from_type<'a>(
         RustType::Simple { id } => {
             if let Some(tp) = types.get(id) {
                 if seen.insert(id) {
-                    res.push(&id);
+                    res.push(id);
                     get_dependencies(*tp, types, res, seen);
                     seen.remove(&id.clone());
                 }

--- a/app/engine/src/type_parser.rs
+++ b/app/engine/src/type_parser.rs
@@ -24,7 +24,7 @@ pub fn parse_rust_type(tokens: &syn::Type) -> Result<RustType, ParseError> {
         }
         syn::Type::Reference(reference) => parse_rust_type(&reference.elem)?,
         syn::Type::Path(path) => {
-            let segment = path.path.segments.iter().last().unwrap();
+            let segment = path.path.segments.iter().next_back().unwrap();
             let id = type_name(&segment.ident);
             let parameters: Vec<RustType> = match &segment.arguments {
                 syn::PathArguments::AngleBracketed(angle_bracketed_arguments) => {

--- a/app/engine/src/visitors.rs
+++ b/app/engine/src/visitors.rs
@@ -1,7 +1,7 @@
 //! Visitors to collect various items from the AST.
 
-use std::{collections::HashSet, iter, mem};
-
+use std::collections::HashSet;
+use std::{iter, mem};
 use syn::{visit::Visit, Attribute, ItemUse, UseTree};
 use typeshare_model::{
     parsed_data::ImportedType,
@@ -118,7 +118,7 @@ impl<'a> TypeShareVisitor<'a> {
             match v {
                 RustEnumVariant::Unit(_) => (),
                 RustEnumVariant::Tuple { ty, .. } => {
-                    all_references.extend(all_reference_type_names(&ty));
+                    all_references.extend(all_reference_type_names(ty));
                 }
                 RustEnumVariant::AnonymousStruct { fields, .. } => {
                     all_references
@@ -145,7 +145,11 @@ impl<'a> TypeShareVisitor<'a> {
         );
 
         // Build a set of a all type names declared in this file
-        let local_types = (self.parsed_data.structs.iter().map(|s| &s.id.original))
+        let local_types = self
+            .parsed_data
+            .structs
+            .iter()
+            .map(|s| &s.id.original)
             .chain(
                 self.parsed_data
                     .enums
@@ -266,7 +270,7 @@ impl<'ast, 'a> Visit<'ast> for TypeShareVisitor<'a> {
         };
 
         self.parsed_data.import_types.extend(
-            parse_import(i, &crate_name)
+            parse_import(i, crate_name)
                 .filter(|imp| !self.ignored_types.contains(&imp.type_name.as_str())),
         );
         syn::visit::visit_item_use(self, i);
@@ -450,8 +454,10 @@ mod test {
     use crate::visitors::ImportedType;
     use cool_asserts::assert_matches;
     use itertools::Itertools;
-    use syn::{visit::Visit, File};
-    use typeshare_model::prelude::{CrateName, FilesMode};
+    use syn::visit::Visit;
+    use syn::File;
+    use typeshare_model::prelude::CrateName;
+    use typeshare_model::FilesMode;
 
     #[test]
     fn test_parse_import_complex() {

--- a/app/engine/src/writer.rs
+++ b/app/engine/src/writer.rs
@@ -61,17 +61,12 @@ pub fn write_multiple_files<'c>(
 
     // TODO: multithread this part
     for (crate_name, parsed_data) in crate_parsed_data {
-        let file_path = output_folder.join(&lang.output_filename_for_crate(&crate_name));
+        let file_path = output_folder.join(lang.output_filename_for_crate(crate_name));
 
         let mut output = Vec::new();
 
-        generate_types(
-            lang,
-            &mut output,
-            parsed_data,
-            FilesMode::Multi(&crate_name),
-        )
-        .with_context(|| format!("error generating typeshare types for crate {crate_name}"))?;
+        generate_types(lang, &mut output, parsed_data, FilesMode::Multi(crate_name))
+            .with_context(|| format!("error generating typeshare types for crate {crate_name}"))?;
 
         check_write_file(&file_path, output).with_context(|| {
             format!(
@@ -180,7 +175,7 @@ fn generate_types<'c>(
 
     if let FilesMode::Multi(crate_name) = mode {
         let all_types = HashMap::new();
-        lang.write_imports(out, crate_name, used_imports(&data, crate_name, &all_types))
+        lang.write_imports(out, crate_name, used_imports(data, crate_name, &all_types))
             .context("error writing imports")?;
     }
 

--- a/app/langs/kotlin/src/lib.rs
+++ b/app/langs/kotlin/src/lib.rs
@@ -419,7 +419,16 @@ impl<'config> Language<'config> for Kotlin<'config> {
 
     fn write_struct(&self, w: &mut impl io::Write, rs: &RustStruct) -> anyhow::Result<()> {
         self.write_comments(w, &rs.comments)?;
-        writeln!(w, "@Serializable")?;
+        
+        if !rs.is_anonymous {
+            if let Some(serializer) = get_custom_serializer(&rs.decorators) {
+                writeln!(w, "@Serializable(with = {}::class)", serializer)?;
+            } else {
+                writeln!(w, "@Serializable")?;
+            }
+        } else {
+            writeln!(w, "@Serializable")?;
+        }
 
         if rs.fields.is_empty() {
             // If the struct has no fields, we can define it as an static object.
@@ -494,7 +503,11 @@ impl<'config> Language<'config> for Kotlin<'config> {
         })?;
 
         self.write_comments(w, &e.shared().comments)?;
-        writeln!(w, "@Serializable")?;
+        if let Some(serializer) = get_custom_serializer(&e.shared().decorators) {
+            writeln!(w, "@Serializable(with = {}::class)", serializer)?;
+        } else {
+            writeln!(w, "@Serializable")?;
+        }
 
         let generic_parameters = (!e.shared().generic_types.is_empty())
             .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
@@ -547,6 +560,19 @@ fn is_inline(decorators: &DecoratorSet) -> bool {
         Value::String(s) => s == "JvmInline",
         _ => false,
     })
+}
+
+fn get_custom_serializer(decorators: &DecoratorSet) -> Option<&str> {
+    decorators.get_all("kotlin")
+        .iter()
+        .find_map(|decorator| match decorator {
+            Value::String(s) if s.starts_with("Serializer") => {
+                s.strip_prefix("Serializer(")
+                    .and_then(|s| s.strip_suffix(")"))
+            },
+            _ => None,
+        })
+        
 }
 
 fn to_pascal_case(value: &str) -> String {

--- a/app/langs/kotlin/src/lib.rs
+++ b/app/langs/kotlin/src/lib.rs
@@ -152,7 +152,7 @@ impl Kotlin<'_> {
                             )?;
                             let variant_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
-                                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                                .map_err(io::Error::other)?;
                             write!(w, "val {}: {}", content_key, variant_type)?;
                             write!(w, ")")?;
                         }
@@ -410,7 +410,7 @@ impl<'config> Language<'config> for Kotlin<'config> {
                     .then(|| format!("<{}>", alias.generic_types.join(", ")))
                     .unwrap_or_default(),
                 self.format_type(&alias.ty, alias.generic_types.as_slice())
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+                    .map_err(std::io::Error::other)?
             )?;
         }
 
@@ -419,7 +419,7 @@ impl<'config> Language<'config> for Kotlin<'config> {
 
     fn write_struct(&self, w: &mut impl io::Write, rs: &RustStruct) -> anyhow::Result<()> {
         self.write_comments(w, &rs.comments)?;
-        
+
         if !rs.is_anonymous {
             if let Some(serializer) = get_custom_serializer(&rs.decorators) {
                 writeln!(w, "@Serializable(with = {}::class)", serializer)?;
@@ -454,7 +454,7 @@ impl<'config> Language<'config> for Kotlin<'config> {
                 let requires_serial_name = rs
                     .fields
                     .iter()
-                    .any(|f| f.id.renamed.as_str().contains(|c: char| c == '-'));
+                    .any(|f| f.id.renamed.as_str().contains('-'));
 
                 if let Some((last, elements)) = rs.fields.split_last() {
                     for f in elements.iter() {
@@ -563,15 +563,15 @@ fn is_inline(decorators: &DecoratorSet) -> bool {
 }
 
 fn get_custom_serializer(decorators: &DecoratorSet) -> Option<&str> {
-    decorators.get_all("kotlin")
+    decorators
+        .get_all("kotlin")
         .iter()
         .find_map(|decorator| match decorator {
             Value::String(s) if s.starts_with("Serializer") => {
                 s.strip_prefix("Serializer(")?.strip_suffix(")")
-            },
+            }
             _ => None,
         })
-        
 }
 
 fn to_pascal_case(value: &str) -> String {

--- a/app/langs/kotlin/src/lib.rs
+++ b/app/langs/kotlin/src/lib.rs
@@ -567,8 +567,7 @@ fn get_custom_serializer(decorators: &DecoratorSet) -> Option<&str> {
         .iter()
         .find_map(|decorator| match decorator {
             Value::String(s) if s.starts_with("Serializer") => {
-                s.strip_prefix("Serializer(")
-                    .and_then(|s| s.strip_suffix(")"))
+                s.strip_prefix("Serializer(")?.strip_suffix(")")
             },
             _ => None,
         })

--- a/app/langs/swift/src/lib.rs
+++ b/app/langs/swift/src/lib.rs
@@ -244,7 +244,7 @@ impl Swift<'_> {
                             let content_optional = ty.is_optional();
                             let case_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
-                                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                                .map_err(io::Error::other)?;
                             write!(w, "({})", swift_keyword_aware_rename(&case_type))?;
 
                             if content_optional {
@@ -735,7 +735,7 @@ impl<'config> Language<'config> for Swift<'config> {
                 let w = &mut w;
 
                 if !rs.fields.is_empty() {
-                    write!(w, "\n")?;
+                    writeln!(w)?;
                 }
 
                 for f in &rs.fields {
@@ -799,7 +799,7 @@ impl<'config> Language<'config> for Swift<'config> {
 
         let coding_keys_info = self
             .write_enum_variants(w, e, make_anonymous_struct_name)
-            .with_context(|| format!("failed to write enum variants"))?;
+            .context("failed to write enum variants")?;
 
         if !coding_keys_info.coding_keys.is_empty() {
             writeln!(
@@ -934,7 +934,7 @@ fn to_camel_case(value: &str) -> String {
 }
 
 fn swift_keyword_aware_rename(name: &str) -> Cow<'_, str> {
-    if SWIFT_KEYWORDS.contains(&name.as_ref()) {
+    if SWIFT_KEYWORDS.contains(&name) {
         Cow::Owned(format!("`{name}`"))
     } else {
         Cow::Borrowed(name)

--- a/app/langs/typescript/src/lib.rs
+++ b/app/langs/typescript/src/lib.rs
@@ -80,9 +80,7 @@ impl Language<'_> for TypeScript {
                 let formatted_type = self.format_type(rtype, generic_context)?;
                 Ok(format!(
                     "[{}]",
-                    std::iter::repeat(&formatted_type)
-                        .take(*len)
-                        .join_with(", ")
+                    std::iter::repeat_n(&formatted_type, *len).join_with(", ")
                 ))
             }
             // We add optionality above the type formatting level
@@ -158,7 +156,7 @@ impl Language<'_> for TypeScript {
 
         let r#type = self
             .format_type(&ty.ty, ty.generic_types.as_slice())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
 
         writeln!(
             w,
@@ -238,9 +236,7 @@ impl Language<'_> for TypeScript {
             ref expr => anyhow::bail!("unsupported const value '{expr:?}'"),
         };
 
-        let const_type = self
-            .format_type(&c.ty, &[])
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let const_type = self.format_type(&c.ty, &[]).map_err(io::Error::other)?;
 
         writeln!(
             w,

--- a/app/model/src/language.rs
+++ b/app/model/src/language.rs
@@ -537,6 +537,7 @@ pub trait Language<'config>: Sized + Sync + Debug {
                         &e.shared().id.original,
                     )],
                     decorators: e.shared().decorators.clone(),
+                    is_anonymous: true,
                 },
             )
             .with_context(|| {

--- a/app/model/src/parsed_data.rs
+++ b/app/model/src/parsed_data.rs
@@ -102,6 +102,8 @@ pub struct RustStruct {
     pub comments: Vec<String>,
     /// Attributes that exist for this struct.
     pub decorators: DecoratorSet,
+    /// If the struct is generated from an anonymous enum variant
+    pub is_anonymous: bool,
 }
 
 /// Rust type alias.


### PR DESCRIPTION
When Kotlin classes are marked with `@Serializable` the Kotlinx serialization compiler plugin automatically generates an implementation of the `KSerializer` interface for the annotated class. In most cases this is fine, but we have run into a scenario where a Rust enum type has significant number of entries (1200+) and the generated serializer is exceeding the JVM maximum method size limit. We need to be able to specify a custom serializer that uses a different strategy to look up serializers for each entry in the enum or the application will fail to compile. 

See https://github.com/Kotlin/kotlinx.serialization/issues/3017

We have a Rust enum that is generating a sealed class hierarchy that looks approximately like the example below. 

```kotlin
@Serializable
sealed class GeneratedSealedClassExample {
    @Serializable
    data object GeneratedSealedClassExample1: GeneratedSealedClassExample()

    ... 

    @Serializable
    data object GeneratedSealedClassExample2500: GeneratedSealedClassExample()
}
```

When the KotlinX serialization compiler plugin runs it generates a serializer that has two arrays containing the class types and serializers for every subclass. As this continues to grow it will exceed the maximum method size and we will not longer be able compile. 

```kotlin
@NotNull
private static final Lazy<KSerializer<Object>> $cachedSerializer$delegate = LazyKt.lazy(LazyThreadSafetyMode.PUBLICATION, () -> {
    return new SealedClassSerializer("org.example.GeneratedSealedClassExample",
            Reflection.getOrCreateKotlinClass(GeneratedSealedClassExample.class),
            new KClass[]{
                    Reflection.getOrCreateKotlinClass(GeneratedSealedClassExample1.class),
                    ...
                    Reflection.getOrCreateKotlinClass(GeneratedSealedClassExample2500.class)
            },
            new KSerializer[]{
                    new ObjectSerializer("org.example.GeneratedSealedClassExample.GeneratedSealedClassExample1", GeneratedSealedClassExample1.INSTANCE, new Annotation[0]),
                    ...
                    new ObjectSerializer("org.example.GeneratedSealedClassExample.GeneratedSealedClassExample2500", GeneratedSealedClassExample2500.INSTANCE, new Annotation[0])
            },
            new Annotation[0]
    );
});
```

Our solution is to utilize a custom serializer that uses runtime reflection to look up the necessary implementation of the `KSerializer`. This solution is approximately 50x slower than the current generated implementation, so ultimately we may need to find another way to look up serializers if that becomes problematic. Benchmarking shows this is on the order of approximately 25 microseconds which is acceptable. 