### PR TITLE
FIx Linting Issues

### DIFF
--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -231,7 +231,7 @@ impl Language for Go {
                     "[{}]",
                     rs.generic_types
                         .iter()
-                        .map(|ty| format!("{} any", ty))
+                        .map(|ty| format!("{ty} any"))
                         .collect::<Vec<String>>()
                         .join(", ")
                 ))
@@ -319,7 +319,7 @@ impl Go {
                     self.acronyms_to_uppercase(tag_key).to_pascal_case()
                 );
 
-                writeln!(w, "type {} string", variant_key_type)?;
+                writeln!(w, "type {variant_key_type} string")?;
                 writeln!(w, "const (")?;
 
                 let mut decoding_cases = Vec::new();
@@ -344,8 +344,7 @@ impl Go {
                         variant_name
                     );
                     decoding_cases.push(format!(
-                        "\tcase {variant_type_const}:\n",
-                        variant_type_const = variant_type_const
+                        "\tcase {variant_type_const}:\n"
                     ));
 
                     if let Some(variant_type) = variant_type {
@@ -361,25 +360,15 @@ impl Go {
 
                         decoding_cases.push(format!(
                             "\t\tvar res {formatted_variant_type}
-\t\t{short_name}.{content_field} = &res
+\t\t{struct_short_name}.{content_field} = &res
 ",
-                            formatted_variant_type = formatted_variant_type,
-                            short_name = struct_short_name,
-                            content_field = content_field,
                         ));
                         variant_accessors.push(format!(
-                            r#"func ({short_name} {full_name}) {variant_name}() {variant_pointer}{formatted_variant_type} {{
-	res, _ := {short_name}.{content_field}.(*{formatted_variant_type})
+                            r#"func ({struct_short_name} {struct_name}) {variant_name}() {variant_pointer}{formatted_variant_type} {{
+	res, _ := {struct_short_name}.{content_field}.(*{formatted_variant_type})
 	return {variant_deref}res
 }}
 "#,
-                            short_name = struct_short_name,
-                            full_name = struct_name,
-                            variant_name = variant_name,
-                            variant_pointer = variant_pointer,
-                            variant_deref = variant_deref,
-                            formatted_variant_type = formatted_variant_type,
-                            content_field = content_field,
                         ));
                         variant_constructors.push(format!(
                             r#"func New{variant_type_const}(content {variant_pointer}{formatted_variant_type}) {struct_name} {{
@@ -389,13 +378,6 @@ impl Go {
     }}
 }}
 "#,
-                            struct_name = struct_name,
-                            tag_field = tag_field,
-                            variant_type_const = variant_type_const,
-                            variant_pointer = variant_pointer,
-                            formatted_variant_type = formatted_variant_type,
-                            variant_ref = variant_ref,
-                            content_field = content_field,
                         ));
                     } else {
                         decoding_cases.push("\t\treturn nil\n".to_string());
@@ -407,9 +389,6 @@ impl Go {
     }}
 }}
 "#,
-                            struct_name = struct_name,
-                            tag_field = tag_field,
-                            variant_type_const = variant_type_const,
                         ));
                     }
 
@@ -425,7 +404,7 @@ impl Go {
 
                 writeln!(w, ")")?;
 
-                writeln!(w, "type {} struct{{ ", struct_name)?;
+                writeln!(w, "type {struct_name} struct{{ ")?;
                 writeln!(
                     w,
                     "\t{} {} `json:{:?}`",
@@ -433,7 +412,7 @@ impl Go {
                     variant_key_type,
                     tag_key,
                 )?;
-                writeln!(w, "\t{} interface{{}}", content_field)?;
+                writeln!(w, "\t{content_field} interface{{}}")?;
                 writeln!(w, "}}")?;
 
                 writeln!(
@@ -517,9 +496,7 @@ func ({short_name} {full_name}) MarshalJSON() ([]byte, error) {{
             w,
             "\t{} {}{} `json:\"{}{}\"`",
             self.format_field_name(field.id.original.to_string(), true),
-            (field.has_default && !field.ty.is_optional())
-                .then_some("*")
-                .unwrap_or_default(),
+            if field.has_default && !field.ty.is_optional() { "*" } else { Default::default() },
             go_type,
             renamed_id,
             option_symbol(is_optional),

--- a/core/src/language/go.rs
+++ b/core/src/language/go.rs
@@ -226,16 +226,18 @@ impl Language for Go {
             w,
             "type {}{} struct {{",
             self.acronyms_to_uppercase(&rs.id.renamed),
-            (!rs.generic_types.is_empty())
-                .then(|| format!(
+            if !rs.generic_types.is_empty() {
+                format!(
                     "[{}]",
                     rs.generic_types
                         .iter()
                         .map(|ty| format!("{ty} any"))
                         .collect::<Vec<String>>()
                         .join(", ")
-                ))
-                .unwrap_or_default()
+                )
+            } else {
+                Default::default()
+            }
         )?;
 
         rs.fields
@@ -343,9 +345,7 @@ impl Go {
                         self.acronyms_to_uppercase(&tag_key.to_string().to_pascal_case()),
                         variant_name
                     );
-                    decoding_cases.push(format!(
-                        "\tcase {variant_type_const}:\n"
-                    ));
+                    decoding_cases.push(format!("\tcase {variant_type_const}:\n"));
 
                     if let Some(variant_type) = variant_type {
                         let (variant_pointer, variant_deref, variant_ref) =
@@ -496,7 +496,11 @@ func ({short_name} {full_name}) MarshalJSON() ([]byte, error) {{
             w,
             "\t{} {}{} `json:\"{}{}\"`",
             self.format_field_name(field.id.original.to_string(), true),
-            if field.has_default && !field.ty.is_optional() { "*" } else { Default::default() },
+            if field.has_default && !field.ty.is_optional() {
+                "*"
+            } else {
+                Default::default()
+            },
             go_type,
             renamed_id,
             option_symbol(is_optional),

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -332,7 +332,7 @@ impl Kotlin {
                     let printed_value = format!(r##""{}""##, &v.shared().id.renamed);
                     self.write_comments(w, 1, &v.shared().comments)?;
                     writeln!(w, "\t@Serializable")?;
-                    writeln!(w, "\t@SerialName({})", printed_value)?;
+                    writeln!(w, "\t@SerialName({printed_value})")?;
 
                     let variant_name = {
                         let mut variant_name = v.shared().id.original.to_pascal_case();
@@ -345,7 +345,7 @@ impl Kotlin {
                         {
                             // If the name starts with a digit just add an underscore
                             // to the front and make it valid
-                            variant_name = format!("_{}", variant_name);
+                            variant_name = format!("_{variant_name}");
                         }
 
                         variant_name
@@ -353,7 +353,7 @@ impl Kotlin {
 
                     match v {
                         RustEnumVariant::Unit(_) => {
-                            write!(w, "\tobject {}", variant_name)?;
+                            write!(w, "\tobject {variant_name}")?;
                         }
                         RustEnumVariant::Tuple { ty, .. } => {
                             write!(
@@ -367,7 +367,7 @@ impl Kotlin {
                             let variant_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
                                 .map_err(std::io::Error::other)?;
-                            write!(w, "val {}: {}", content_key, variant_type)?;
+                            write!(w, "val {content_key}: {variant_type}")?;
                             write!(w, ")")?;
                         }
                         RustEnumVariant::AnonymousStruct { shared, fields } => {

--- a/core/src/language/kotlin.rs
+++ b/core/src/language/kotlin.rs
@@ -168,9 +168,11 @@ impl Language for Kotlin {
                 w,
                 "typealias {}{} = {}\n",
                 type_name,
-                (!ty.generic_types.is_empty())
-                    .then(|| format!("<{}>", ty.generic_types.join(", ")))
-                    .unwrap_or_default(),
+                if !ty.generic_types.is_empty() {
+                    format!("<{}>", ty.generic_types.join(", "))
+                } else {
+                    Default::default()
+                },
                 self.format_type(&ty.r#type, ty.generic_types.as_slice())
                     .map_err(std::io::Error::other)?
             )?;
@@ -196,9 +198,11 @@ impl Language for Kotlin {
                 "data class {}{}{} (",
                 self.prefix,
                 rs.id.renamed,
-                (!rs.generic_types.is_empty())
-                    .then(|| format!("<{}>", rs.generic_types.join(", ")))
-                    .unwrap_or_default()
+                if !rs.generic_types.is_empty() {
+                    format!("<{}>", rs.generic_types.join(", "))
+                } else {
+                    Default::default()
+                }
             )?;
 
             // Use @SerialName when writing the struct
@@ -253,9 +257,11 @@ impl Language for Kotlin {
         self.write_comments(w, 0, &e.shared().comments)?;
         writeln!(w, "@Serializable")?;
 
-        let generic_parameters = (!e.shared().generic_types.is_empty())
-            .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
-            .unwrap_or_default();
+        let generic_parameters = if !e.shared().generic_types.is_empty() {
+            format!("<{}>", e.shared().generic_types.join(", "))
+        } else {
+            Default::default()
+        };
 
         match e {
             RustEnum::Unit(..) => {
@@ -360,9 +366,11 @@ impl Kotlin {
                                 w,
                                 "\tdata class {}{}(",
                                 variant_name,
-                                (!e.shared().generic_types.is_empty())
-                                    .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
-                                    .unwrap_or_default()
+                                if !e.shared().generic_types.is_empty() {
+                                    format!("<{}>", e.shared().generic_types.join(", "))
+                                } else {
+                                    Default::default()
+                                }
                             )?;
                             let variant_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
@@ -375,9 +383,11 @@ impl Kotlin {
                                 w,
                                 "\tdata class {}{}(",
                                 variant_name,
-                                (!e.shared().generic_types.is_empty())
-                                    .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
-                                    .unwrap_or_default()
+                                if !e.shared().generic_types.is_empty() {
+                                    format!("<{}>", e.shared().generic_types.join(", "))
+                                } else {
+                                    Default::default()
+                                }
                             )?;
 
                             // Builds the list of generic types (e.g [T, U, V]), by digging
@@ -418,9 +428,11 @@ impl Kotlin {
                         ": {}{}{}()",
                         self.prefix,
                         e.shared().id.original,
-                        (!e.shared().generic_types.is_empty())
-                            .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
-                            .unwrap_or_default()
+                        if !e.shared().generic_types.is_empty() {
+                            format!("<{}>", e.shared().generic_types.join(", "))
+                        } else {
+                            Default::default()
+                        }
                     )?;
                 }
             }

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -256,7 +256,11 @@ pub trait Language {
             Ok(format!(
                 "{}{}",
                 self.format_simple_type(base, generic_types)?,
-                if !parameters.is_empty() { self.format_generic_parameters(parameters) } else { Default::default() }
+                if !parameters.is_empty() {
+                    self.format_generic_parameters(parameters)
+                } else {
+                    Default::default()
+                }
             ))
         }
     }

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -256,9 +256,7 @@ pub trait Language {
             Ok(format!(
                 "{}{}",
                 self.format_simple_type(base, generic_types)?,
-                (!parameters.is_empty())
-                    .then(|| self.format_generic_parameters(parameters))
-                    .unwrap_or_default()
+                if !parameters.is_empty() { self.format_generic_parameters(parameters) } else { Default::default() }
             ))
         }
     }

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -178,9 +178,11 @@ impl Language for Python {
             Ok(format!(
                 "{}{}",
                 self.format_simple_type(base, generic_types)?,
-                (!parameters.is_empty())
-                    .then(|| format!("[{}]", parameters.join(", ")))
-                    .unwrap_or_default()
+                if !parameters.is_empty() {
+                    format!("[{}]", parameters.join(", "))
+                } else {
+                    Default::default()
+                }
             ))
         }
     }
@@ -279,9 +281,11 @@ impl Language for Python {
             w,
             "{}{} = {}\n",
             ty.id.renamed,
-            (!ty.generic_types.is_empty())
-                .then(|| format!("[{}]", ty.generic_types.join(", ")))
-                .unwrap_or_default(),
+            if !ty.generic_types.is_empty() {
+                format!("[{}]", ty.generic_types.join(", "))
+            } else {
+                Default::default()
+            },
             r#type,
         )?;
 

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -508,19 +508,19 @@ impl Python {
                         indent = indent,
                         indented_comments = comments
                             .iter()
-                            .map(|v| format!("{}{}", indent, v))
+                            .map(|v| format!("{indent}{v}"))
                             .collect::<Vec<String>>()
                             .join("\n"),
                     )
                 } else {
                     comments
                         .iter()
-                        .map(|v| format!("{}# {}", indent, v))
+                        .map(|v| format!("{indent}# {v}"))
                         .collect::<Vec<String>>()
                         .join("\n")
                 }
             };
-            writeln!(w, "{}", comment)?;
+            writeln!(w, "{comment}")?;
         }
         Ok(())
     }
@@ -540,7 +540,7 @@ impl Python {
         type_var_names.sort();
         let type_vars: Vec<String> = type_var_names
             .iter()
-            .map(|name| format!("{} = TypeVar(\"{}\")", name, name))
+            .map(|name| format!("{name} = TypeVar(\"{name}\")"))
             .collect();
         let mut imports = vec![];
         for (import_module, identifiers) in &self.imports {
@@ -588,12 +588,12 @@ impl Python {
             w,
             "    {content_key}{}{}",
             if let Some(content_type) = content_type {
-                format!(": {}", content_type)
+                format!(": {content_type}")
             } else {
                 "".to_string()
             },
             if let Some(content_value) = content_value {
-                format!(" = {}", content_value)
+                format!(" = {content_value}")
             } else {
                 "".to_string()
             }
@@ -630,7 +630,7 @@ impl Python {
         let enum_type_class_name = format!("{}Types", shared.id.renamed);
         self.add_import("enum".to_string(), "Enum".to_string());
         // write "types" class: a union of all the enum variants
-        writeln!(w, "class {}(str, Enum):", enum_type_class_name)?;
+        writeln!(w, "class {enum_type_class_name}(str, Enum):")?;
         writeln!(
             w,
             "{}",
@@ -737,7 +737,7 @@ fn get_python_keywords() -> &'static HashSet<String> {
 fn python_property_aware_rename(name: &str) -> String {
     let snake_name = name.to_case(Case::Snake);
     match get_python_keywords().contains(&snake_name) {
-        true => format!("{}_", name),
+        true => format!("{name}_"),
         false => snake_name,
     }
 }

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -133,7 +133,7 @@ impl Language for Scala {
         match self.package.rsplit_once('.') {
             None => {}
             Some((parent, _last)) => {
-                writeln!(w, "package {}", parent)?;
+                writeln!(w, "package {parent}")?;
                 writeln!(w)?;
             }
         };
@@ -274,7 +274,7 @@ impl Scala {
                         {
                             // If the name starts with a digit just add an underscore
                             // to the front and make it valid
-                            variant_name = format!("_{}", variant_name);
+                            variant_name = format!("_{variant_name}");
                         }
 
                         variant_name
@@ -282,7 +282,7 @@ impl Scala {
 
                     match v {
                         RustEnumVariant::Unit(_) => {
-                            write!(w, "\tcase object {}", variant_name)?;
+                            write!(w, "\tcase object {variant_name}")?;
                         }
                         RustEnumVariant::Tuple { ty, .. } => {
                             write!(
@@ -296,7 +296,7 @@ impl Scala {
                             let variant_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
                                 .map_err(std::io::Error::other)?;
-                            write!(w, "{}: {}", content_key, variant_type)?;
+                            write!(w, "{content_key}: {variant_type}")?;
                             write!(w, ")")?;
                         }
                         RustEnumVariant::AnonymousStruct { shared, fields } => {
@@ -349,7 +349,7 @@ impl Scala {
                             .then(|| format!("[{}]", e.shared().generic_types.join(", ")))
                             .unwrap_or_default()
                     )?;
-                    writeln!(w, "\t\tval serialName: String = {}", printed_value)?;
+                    writeln!(w, "\t\tval serialName: String = {printed_value}")?;
                     writeln!(w, "\t}}")?;
                 }
             }
@@ -410,7 +410,7 @@ impl Scala {
         match self.package.rsplit_once('.') {
             None => {}
             Some((_parent, last)) => {
-                writeln!(w, "package object {} {{", last)?;
+                writeln!(w, "package object {last} {{")?;
                 writeln!(w)?;
             }
         };
@@ -421,7 +421,7 @@ impl Scala {
         match self.package.rsplit_once('.') {
             None => {}
             Some((_parent, last)) => {
-                writeln!(w, "package {} {{", last)?;
+                writeln!(w, "package {last} {{")?;
                 writeln!(w)?;
             }
         };

--- a/core/src/language/scala.rs
+++ b/core/src/language/scala.rs
@@ -147,9 +147,11 @@ impl Language for Scala {
             w,
             "type {}{} = {}\n",
             ty.id.original,
-            (!ty.generic_types.is_empty())
-                .then(|| format!("[{}]", ty.generic_types.join(", ")))
-                .unwrap_or_default(),
+            if !ty.generic_types.is_empty() {
+                format!("[{}]", ty.generic_types.join(", "))
+            } else {
+                Default::default()
+            },
             self.format_type(&ty.r#type, ty.generic_types.as_slice())
                 .map_err(std::io::Error::other)?
         )?;
@@ -169,9 +171,11 @@ impl Language for Scala {
                 w,
                 "case class {}{} (",
                 rs.id.renamed,
-                (!rs.generic_types.is_empty())
-                    .then(|| format!("[{}]", rs.generic_types.join(", ")))
-                    .unwrap_or_default()
+                if !rs.generic_types.is_empty() {
+                    format!("[{}]", rs.generic_types.join(", "))
+                } else {
+                    Default::default()
+                }
             )?;
 
             if let Some((last, elements)) = rs.fields.split_last() {
@@ -197,9 +201,11 @@ impl Language for Scala {
 
         self.write_comments(w, 0, &e.shared().comments)?;
 
-        let generic_parameters = (!e.shared().generic_types.is_empty())
-            .then(|| format!("[{}]", e.shared().generic_types.join(", ")))
-            .unwrap_or_default();
+        let generic_parameters = if !e.shared().generic_types.is_empty() {
+            format!("[{}]", e.shared().generic_types.join(", "))
+        } else {
+            Default::default()
+        };
 
         match e {
             RustEnum::Unit(shared) => {
@@ -284,14 +290,17 @@ impl Scala {
                         RustEnumVariant::Unit(_) => {
                             write!(w, "\tcase object {variant_name}")?;
                         }
+
                         RustEnumVariant::Tuple { ty, .. } => {
                             write!(
                                 w,
                                 "\tcase class {}{}(",
                                 variant_name,
-                                (!e.shared().generic_types.is_empty())
-                                    .then(|| format!("[{}]", e.shared().generic_types.join(", ")))
-                                    .unwrap_or_default()
+                                if !e.shared().generic_types.is_empty() {
+                                    format!("[{}]", e.shared().generic_types.join(", "))
+                                } else {
+                                    Default::default()
+                                }
                             )?;
                             let variant_type = self
                                 .format_type(ty, e.shared().generic_types.as_slice())
@@ -304,9 +313,11 @@ impl Scala {
                                 w,
                                 "\tcase class {}{}(",
                                 variant_name,
-                                (!e.shared().generic_types.is_empty())
-                                    .then(|| format!("[{}]", e.shared().generic_types.join(", ")))
-                                    .unwrap_or_default()
+                                if !e.shared().generic_types.is_empty() {
+                                    format!("[{}]", e.shared().generic_types.join(", "))
+                                } else {
+                                    Default::default()
+                                }
                             )?;
 
                             // Builds the list of generic types (e.g [T, U, V]), by digging
@@ -345,9 +356,11 @@ impl Scala {
                         w,
                         " extends {}{} {{",
                         e.shared().id.original,
-                        (!e.shared().generic_types.is_empty())
-                            .then(|| format!("[{}]", e.shared().generic_types.join(", ")))
-                            .unwrap_or_default()
+                        if !e.shared().generic_types.is_empty() {
+                            format!("[{}]", e.shared().generic_types.join(", "))
+                        } else {
+                            Default::default()
+                        }
                     )?;
                     writeln!(w, "\t\tval serialName: String = {printed_value}")?;
                     writeln!(w, "\t}}")?;

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -343,9 +343,7 @@ impl Language for Swift {
                 "\tpublic let {}: {}{}",
                 remove_dash_from_identifier(swift_keyword_aware_rename(&f.id.renamed).as_ref()),
                 case_type,
-                (f.has_default && !f.ty.is_optional())
-                    .then_some("?")
-                    .unwrap_or_default()
+                if f.has_default && !f.ty.is_optional() { "?" } else { Default::default() }
             )?;
         }
 
@@ -377,9 +375,7 @@ impl Language for Swift {
                 "{}: {}{}",
                 remove_dash_from_identifier(&f.id.renamed),
                 swift_ty,
-                (f.has_default && !f.ty.is_optional())
-                    .then_some("?")
-                    .unwrap_or_default()
+                if f.has_default && !f.ty.is_optional() { "?" } else { Default::default() }
             ));
         }
 
@@ -593,7 +589,7 @@ impl Swift {
                         {
                             // If the name starts with a digit just add an underscore
                             // to the front and make it valid
-                            variant_name = format!("_{}", variant_name);
+                            variant_name = format!("_{variant_name}");
                         }
 
                         variant_name
@@ -795,7 +791,7 @@ impl Swift {
 
     /// Write the `CodableVoid` type.
     fn write_codable(&self, w: &mut dyn Write, output_string: &str) -> io::Result<()> {
-        writeln!(w, "{}", output_string)
+        writeln!(w, "{output_string}")
     }
 
     /// Build the generic constraints output. This checks for the `swiftGenericConstraints` typeshare attribute and combines

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -254,9 +254,11 @@ impl Language for Swift {
             w,
             "public typealias {}{} = {}",
             type_name,
-            (!ty.generic_types.is_empty())
-                .then(|| format!("<{}>", ty.generic_types.join(", ")))
-                .unwrap_or_default(),
+            if !ty.generic_types.is_empty() {
+                format!("<{}>", ty.generic_types.join(", "))
+            } else {
+                Default::default()
+            },
             self.format_type(&ty.r#type, ty.generic_types.as_slice())
                 .map_err(std::io::Error::other)?
         )?;
@@ -302,9 +304,11 @@ impl Language for Swift {
         writeln!(
             w,
             "public struct {type_name}{}: {} {{",
-            (!rs.generic_types.is_empty())
-                .then(|| format!("<{generic_names_and_constraints}>",))
-                .unwrap_or_default(),
+            if !rs.generic_types.is_empty() {
+                format!("<{generic_names_and_constraints}>",)
+            } else {
+                Default::default()
+            },
             decs
         )?;
 
@@ -343,7 +347,11 @@ impl Language for Swift {
                 "\tpublic let {}: {}{}",
                 remove_dash_from_identifier(swift_keyword_aware_rename(&f.id.renamed).as_ref()),
                 case_type,
-                if f.has_default && !f.ty.is_optional() { "?" } else { Default::default() }
+                if f.has_default && !f.ty.is_optional() {
+                    "?"
+                } else {
+                    Default::default()
+                }
             )?;
         }
 
@@ -375,7 +383,11 @@ impl Language for Swift {
                 "{}: {}{}",
                 remove_dash_from_identifier(&f.id.renamed),
                 swift_ty,
-                if f.has_default && !f.ty.is_optional() { "?" } else { Default::default() }
+                if f.has_default && !f.ty.is_optional() {
+                    "?"
+                } else {
+                    Default::default()
+                }
             ));
         }
 
@@ -450,9 +462,11 @@ impl Language for Swift {
         writeln!(
             w,
             "public {indirect}enum {enum_name}{}: {} {{",
-            (!e.shared().generic_types.is_empty())
-                .then(|| format!("<{generic_names_and_constraints}>",))
-                .unwrap_or_default(),
+            if !e.shared().generic_types.is_empty() {
+                format!("<{generic_names_and_constraints}>",)
+            } else {
+                Default::default()
+            },
             decs
         )?;
 

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -158,12 +158,17 @@ export const ReplacerFunc = (key: string, value: unknown): unknown => {{
             w,
             "export type {}{} = {}{};\n",
             ty.id.renamed,
-            (!ty.generic_types.is_empty())
-                .then(|| format!("<{}>", ty.generic_types.join(", ")))
-                .unwrap_or_default(),
+            if !ty.generic_types.is_empty() {
+                format!("<{}>", ty.generic_types.join(", "))
+            } else {
+                Default::default()
+            },
             r#type,
-            if ty.r#type
-                .is_optional() { " | undefined" } else { Default::default() },
+            if ty.r#type.is_optional() {
+                " | undefined"
+            } else {
+                Default::default()
+            },
         )?;
 
         Ok(())
@@ -192,9 +197,11 @@ export const ReplacerFunc = (key: string, value: unknown): unknown => {{
             w,
             "export interface {}{} {{",
             rs.id.renamed,
-            (!rs.generic_types.is_empty())
-                .then(|| format!("<{}>", rs.generic_types.join(", ")))
-                .unwrap_or_default()
+            if !rs.generic_types.is_empty() {
+                format!("<{}>", rs.generic_types.join(", "))
+            } else {
+                Default::default()
+            }
         )?;
 
         rs.fields
@@ -207,9 +214,11 @@ export const ReplacerFunc = (key: string, value: unknown): unknown => {{
     fn write_enum(&mut self, w: &mut dyn Write, e: &RustEnum) -> io::Result<()> {
         self.write_comments(w, 0, &e.shared().comments)?;
 
-        let generic_parameters = (!e.shared().generic_types.is_empty())
-            .then(|| format!("<{}>", e.shared().generic_types.join(", ")))
-            .unwrap_or_default();
+        let generic_parameters = if !e.shared().generic_types.is_empty() {
+            format!("<{}>", e.shared().generic_types.join(", "))
+        } else {
+            Default::default()
+        };
 
         match e {
             RustEnum::Unit(shared) => {
@@ -297,7 +306,11 @@ impl TypeScript {
                             tag_key,
                             shared.id.renamed,
                             content_key,
-                            if ty.is_optional() { "?" } else { Default::default() },
+                            if ty.is_optional() {
+                                "?"
+                            } else {
+                                Default::default()
+                            },
                             r#type
                         )
                     }
@@ -352,11 +365,19 @@ impl TypeScript {
         writeln!(
             w,
             "\t{}{}{}: {}{};",
-            if is_readonly { "readonly " } else { Default::default() },
+            if is_readonly {
+                "readonly "
+            } else {
+                Default::default()
+            },
             typescript_property_aware_rename(&field.id.renamed),
             if optional { "?" } else { Default::default() },
             ts_ty,
-            if double_optional { " | null" } else { Default::default() }
+            if double_optional {
+                " | null"
+            } else {
+                Default::default()
+            }
         )?;
 
         Ok(())

--- a/core/src/language/typescript.rs
+++ b/core/src/language/typescript.rs
@@ -162,10 +162,8 @@ export const ReplacerFunc = (key: string, value: unknown): unknown => {{
                 .then(|| format!("<{}>", ty.generic_types.join(", ")))
                 .unwrap_or_default(),
             r#type,
-            ty.r#type
-                .is_optional()
-                .then_some(" | undefined")
-                .unwrap_or_default(),
+            if ty.r#type
+                .is_optional() { " | undefined" } else { Default::default() },
         )?;
 
         Ok(())
@@ -299,7 +297,7 @@ impl TypeScript {
                             tag_key,
                             shared.id.renamed,
                             content_key,
-                            ty.is_optional().then_some("?").unwrap_or_default(),
+                            if ty.is_optional() { "?" } else { Default::default() },
                             r#type
                         )
                     }
@@ -354,11 +352,11 @@ impl TypeScript {
         writeln!(
             w,
             "\t{}{}{}: {}{};",
-            is_readonly.then_some("readonly ").unwrap_or_default(),
+            if is_readonly { "readonly " } else { Default::default() },
             typescript_property_aware_rename(&field.id.renamed),
-            optional.then_some("?").unwrap_or_default(),
+            if optional { "?" } else { Default::default() },
             ts_ty,
-            double_optional.then_some(" | null").unwrap_or_default()
+            if double_optional { " | null" } else { Default::default() }
         )?;
 
         Ok(())
@@ -378,17 +376,15 @@ impl TypeScript {
                 if comments.len() == 1 {
                     format!("{}/** {} */", tab_indent, comments.first().unwrap())
                 } else {
-                    let joined_comments = comments.join(&format!("\n{} * ", tab_indent));
+                    let joined_comments = comments.join(&format!("\n{tab_indent} * "));
                     format!(
-                        "{tab}/**
-{tab} * {comment}
-{tab} */",
-                        tab = tab_indent,
-                        comment = joined_comments
+                        "{tab_indent}/**
+{tab_indent} * {joined_comments}
+{tab_indent} */"
                     )
                 }
             };
-            writeln!(w, "{}", comment)?;
+            writeln!(w, "{comment}")?;
         }
         Ok(())
     }
@@ -437,7 +433,7 @@ impl TypeScript {
 
 fn typescript_property_aware_rename(name: &str) -> String {
     if name.chars().any(|c| c == '-') {
-        return format!("{:?}", name);
+        return format!("{name:?}");
     }
     name.to_string()
 }

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -49,8 +49,7 @@ mod blocklisted_types {
     pub struct Foo {{
         pub bar: {ty},
     }}
-    "##,
-            ty = ty
+    "##
         );
 
         let mut out: Vec<u8> = Vec::new();

--- a/lib/src/integer.rs
+++ b/lib/src/integer.rs
@@ -280,7 +280,7 @@ mod tests {
         let value: I54 = 125.into();
 
         // Right-aligned, include the + sign, width=8,
-        assert_eq!(format!("{:>+8}", value), "    +125");
+        assert_eq!(format!("{value:>+8}"), "    +125");
     }
 
     #[test]


### PR DESCRIPTION
The linting pipeline has been failing due to some changes to clippy's linting. This MR should fix this. 

The changes were added by running `cargo clippy --fix` which automatically fixed some of the issues. Some changes following the pattern of `().then(...).unwrap_or_default()` within the code had to be manually fixed to resolve multiple occurrences of https://rust-lang.github.io/rust-clippy/master/index.html#obfuscated_if_else
