### PR TITLE
Use Span to capture line and column numbers for parsing rejections.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.30.2"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb03342077df16d5b1400d7bed00156882846d7a479ff61a6f10594bcc3423d8"
+checksum = "759bfa52db036a2db54f0b5f0ff164efa249b3014720459c5ea4198380c529bc"
 dependencies = [
  "chrono",
  "log",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -668,37 +668,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "topological-sort"
@@ -959,9 +964,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
-dependencies = [
- "memchr",
-]
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ inherits = "release"
 
 [workspace.dependencies]
 log = "0.4"
-flexi_logger = "0.30"
+flexi_logger = "0.31"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,15 +17,15 @@ python = []
 
 [dependencies]
 clap = { version = "4.5", features = [
-  "cargo",
-  "derive",
-  "unicode",
-  "wrap_help",
+    "cargo",
+    "derive",
+    "unicode",
+    "wrap_help",
 ] }
 ignore = "0.4"
 once_cell = "1"
 serde = { version = "1", features = ["derive"] }
-toml = "0.8"
+toml = "0.9"
 typeshare-core = { path = "../core", version = "=1.13.3" }
 log.workspace = true
 flexi_logger.workspace = true

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -138,7 +138,10 @@ fn generate_types(config_file: Option<&Path>, options: &Args) -> anyhow::Result<
 
     check_parse_errors(&parsed_data)?;
 
-    info!("typeshare started writing generated types");
+    info!(
+        "typeshare started writing {} generated types",
+        parsed_data.len()
+    );
 
     write_generated(destination, lang.as_mut(), parsed_data, import_candidates)?;
 

--- a/cli/src/parse.rs
+++ b/cli/src/parse.rs
@@ -3,7 +3,6 @@ use anyhow::anyhow;
 use anyhow::Context;
 use crossbeam::channel::bounded;
 use ignore::{DirEntry, WalkBuilder, WalkState};
-use std::borrow::Cow;
 use std::{
     collections::{BTreeMap, HashMap},
     mem, thread,
@@ -99,13 +98,12 @@ impl std::error::Error for ParseDirError {}
 
 impl std::fmt::Display for ParseDirError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match &self {
-            ParseDirError::IO(s) => Cow::Borrowed(s),
+        match &self {
+            ParseDirError::IO(s) => f.write_str(s),
             ParseDirError::ParseError(parse_error_with_span) => {
-                Cow::Owned(parse_error_with_span.to_string())
+                write!(f, "{parse_error_with_span}")
             }
-        };
-        write!(f, "{s}")
+        }
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,7 @@ description = "The code generator used by Typeshare's command line tool"
 repository = "https://github.com/1Password/typeshare"
 
 [dependencies]
-proc-macro2 = "1"
+proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 syn = { version = "2", features = ["full", "visit"] }
 thiserror = "2"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,8 +1,7 @@
 //! Error types for parsing.
+use crate::rust_types::RustTypeParseError;
 use proc_macro2::Span;
 use thiserror::Error;
-
-use crate::rust_types::RustTypeParseError;
 
 #[derive(Debug)]
 /// Wrapper for a parse error which includes a span.
@@ -61,10 +60,28 @@ pub enum ParseError {
     IOError(String),
 }
 
-/// Convert a [`RustTypeParseError`] into a [`ParseErrorWithSpan`].
-pub fn rust_type_parse_err(err: RustTypeParseError, span: Span) -> ParseErrorWithSpan {
-    ParseErrorWithSpan {
-        error: ParseError::RustTypeParseError(err),
-        span,
+impl RustTypeParseError {
+    /// Convert a [`RustTypeParseError`] into a [`ParseErrorWithSpan`].
+    pub fn with_span(self, span: Span) -> ParseErrorWithSpan {
+        ParseError::RustTypeParseError(self).with_span(span)
+    }
+}
+
+impl ParseError {
+    /// If a condition is not met then call the error function.
+    pub fn ensure(
+        cond: bool,
+        mut f: impl FnMut() -> ParseErrorWithSpan,
+    ) -> Result<(), ParseErrorWithSpan> {
+        if !cond {
+            Err(f())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Convert a [`ParseError`] into a [`ParseErrorWithSpan`].
+    pub fn with_span(self, span: Span) -> ParseErrorWithSpan {
+        ParseErrorWithSpan { error: self, span }
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,65 @@
+use proc_macro2::Span;
+use thiserror::Error;
+
+use crate::rust_types::RustTypeParseError;
+
+#[derive(Debug)]
+pub struct ParseErrorWithSpan {
+    pub error: ParseError,
+    pub span: Span,
+}
+
+impl std::error::Error for ParseErrorWithSpan {}
+
+impl std::fmt::Display for ParseErrorWithSpan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}, line {}, column {}",
+            self.error,
+            self.span.start().line,
+            self.span.start().column
+        )
+    }
+}
+
+/// Errors that can occur while parsing Rust source input.
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum ParseError {
+    #[error("{0}")]
+    SynError(#[from] syn::Error),
+    #[error("Failed to parse a rust type: {0}")]
+    RustTypeParseError(#[from] RustTypeParseError),
+    #[error("Unsupported language encountered: {0}")]
+    UnsupportedLanguage(String),
+    #[error("Unsupported type encountered: {0}")]
+    UnsupportedType(String),
+    #[error("Tuple structs with more than one field are currently unsupported")]
+    ComplexTupleStruct,
+    #[error("Multiple unnamed associated types are not currently supported")]
+    MultipleUnnamedAssociatedTypes,
+    #[error("The serde tag attribute is not supported for non-algebraic enums: {enum_ident}")]
+    SerdeTagNotAllowed { enum_ident: String },
+    #[error("The serde content attribute is not supported for non-algebraic enums: {enum_ident}")]
+    SerdeContentNotAllowed { enum_ident: String },
+    #[error("Serde tag attribute needs to be specified for algebraic enum {enum_ident}. e.g. #[serde(tag = \"type\", content = \"content\")]")]
+    SerdeTagRequired { enum_ident: String },
+    #[error("Serde content attribute needs to be specified for algebraic enum {enum_ident}. e.g. #[serde(tag = \"type\", content = \"content\")]")]
+    SerdeContentRequired { enum_ident: String },
+    #[error("The expression assigned to this constant variable is not a numeric literal")]
+    RustConstExprInvalid,
+    #[error("You cannot use typeshare on a constant that is not a numeric literal")]
+    RustConstTypeInvalid,
+    #[error("The serde flatten attribute is not currently supported")]
+    SerdeFlattenNotAllowed,
+    #[error("IO error: {0}")]
+    IOError(String),
+}
+
+pub fn rust_type_parse_err(err: RustTypeParseError, span: Span) -> ParseErrorWithSpan {
+    ParseErrorWithSpan {
+        error: ParseError::RustTypeParseError(err),
+        span,
+    }
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,5 +1,5 @@
 //! Error types for parsing.
-use crate::rust_types::RustTypeParseError;
+use itertools::Itertools as _;
 use proc_macro2::Span;
 use thiserror::Error;
 
@@ -92,4 +92,17 @@ pub enum GenerationError {
     /// The post generation step failed.
     #[error("Post generation failed: {0}")]
     PostGeneration(String),
+}
+
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+pub enum RustTypeParseError {
+    #[error("Unsupported type: \"{}\"", .0.iter().join(","))]
+    UnsupportedType(Vec<String>),
+    #[error("Unexpected token when parsing type: `{0}`. This is an internal error, please ping a typeshare developer to resolve this problem.")]
+    UnexpectedToken(String),
+    #[error("Tuples are not allowed in typeshare types")]
+    UnexpectedParameterizedTuple,
+    #[error("Could not parse numeric literal")]
+    NumericLiteral(syn::parse::Error),
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,11 +1,15 @@
+//! Error types for parsing.
 use proc_macro2::Span;
 use thiserror::Error;
 
 use crate::rust_types::RustTypeParseError;
 
 #[derive(Debug)]
+/// Wrapper for a parse error which includes a span.
 pub struct ParseErrorWithSpan {
+    /// Parse error
     pub error: ParseError,
+    /// Span
     pub span: Span,
 }
 
@@ -57,6 +61,7 @@ pub enum ParseError {
     IOError(String),
 }
 
+/// Convert a [`RustTypeParseError`] into a [`ParseErrorWithSpan`].
 pub fn rust_type_parse_err(err: RustTypeParseError, span: Span) -> ParseErrorWithSpan {
     ParseErrorWithSpan {
         error: ParseError::RustTypeParseError(err),

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -18,7 +18,7 @@ impl std::fmt::Display for ParseErrorWithSpan {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}, line {}, column {}",
+            "{}, on line {} and column {}",
             self.error,
             self.span.start().line,
             self.span.start().column

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -60,28 +60,21 @@ pub enum ParseError {
     IOError(String),
 }
 
-impl RustTypeParseError {
-    /// Convert a [`RustTypeParseError`] into a [`ParseErrorWithSpan`].
-    pub fn with_span(self, span: Span) -> ParseErrorWithSpan {
+/// Parse error types that can capture a span and convert
+/// into the top level [ParseErrorWithSpan] type.
+pub trait WithSpan {
+    /// Convert [Self] into a [`ParserErrorWithSpan`].
+    fn with_span(self, span: Span) -> ParseErrorWithSpan;
+}
+
+impl WithSpan for RustTypeParseError {
+    fn with_span(self, span: Span) -> ParseErrorWithSpan {
         ParseError::RustTypeParseError(self).with_span(span)
     }
 }
 
-impl ParseError {
-    /// If a condition is not met then call the error function.
-    pub fn ensure(
-        cond: bool,
-        mut f: impl FnMut() -> ParseErrorWithSpan,
-    ) -> Result<(), ParseErrorWithSpan> {
-        if !cond {
-            Err(f())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Convert a [`ParseError`] into a [`ParseErrorWithSpan`].
-    pub fn with_span(self, span: Span) -> ParseErrorWithSpan {
+impl WithSpan for ParseError {
+    fn with_span(self, span: Span) -> ParseErrorWithSpan {
         ParseErrorWithSpan { error: self, span }
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -85,3 +85,11 @@ impl ParseError {
         ParseErrorWithSpan { error: self, span }
     }
 }
+
+#[derive(Debug, Error)]
+/// Errors during file generation.
+pub enum GenerationError {
+    /// The post generation step failed.
+    #[error("Post generation failed: {0}")]
+    PostGeneration(String),
+}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 /// Wrapper for a parse error which includes a span.
 pub struct ParseErrorWithSpan {
     /// Parse error
-    pub error: ParseError,
+    error: ParseError,
     /// Span
-    pub span: Span,
+    span: Span,
 }
 
 impl std::error::Error for ParseErrorWithSpan {}

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for ParseErrorWithSpan {
 pub enum ParseError {
     #[error("{0}")]
     SynError(#[from] syn::Error),
-    #[error("Failed to parse a rust type: {0}")]
+    #[error("Failed to parse a Rust type: {0}")]
     RustTypeParseError(#[from] RustTypeParseError),
     #[error("Unsupported language encountered: {0}")]
     UnsupportedLanguage(String),

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
-    parser::{ParseError, ParsedData},
+    error::ParseError,
+    parser::ParsedData,
     rust_types::{
         Id, RustConst, RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias,
         RustTypeFormatError, SpecialRustType,

--- a/core/src/language/mod.rs
+++ b/core/src/language/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::ParseError,
+    error::{GenerationError, ParseError},
     parser::ParsedData,
     rust_types::{
         Id, RustConst, RustEnum, RustEnumVariant, RustItem, RustStruct, RustType, RustTypeAlias,
@@ -7,7 +7,6 @@ use crate::{
     },
     topsort::topsort,
     visitors::ImportedType,
-    GenerationError,
 };
 use itertools::Itertools;
 use log::warn;

--- a/core/src/language/swift.rs
+++ b/core/src/language/swift.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::GenerationError,
     language::{Language, SupportedLanguage},
     parser::{remove_dash_from_identifier, DecoratorKind, ParsedData},
     rename::RenameExt,
@@ -6,7 +7,6 @@ use crate::{
         DecoratorMap, RustConst, RustEnum, RustEnumVariant, RustStruct, RustTypeAlias,
         RustTypeFormatError, SpecialRustType,
     },
-    GenerationError,
 };
 use itertools::{Either, Itertools};
 use joinery::JoinableIterator;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,7 +1,5 @@
 //! The core library for typeshare.
 //! Contains the parser and language converters.
-use thiserror::Error;
-
 pub mod context;
 pub mod error;
 /// Implementations for each language converter
@@ -17,20 +15,3 @@ mod topsort;
 mod visitors;
 
 pub use rename::RenameExt;
-
-#[derive(Debug, Error)]
-#[allow(missing_docs)]
-pub enum ProcessInputError {
-    #[error("a parsing error occurred: {0}")]
-    ParseError(#[from] error::ParseError),
-    #[error("a type generation error occurred: {0}")]
-    IoError(#[from] std::io::Error),
-}
-
-#[derive(Debug, Error)]
-/// Errors during file generation.
-pub enum GenerationError {
-    /// The post generation step failed.
-    #[error("Post generation failed: {0}")]
-    PostGeneration(String),
-}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 pub mod context;
+pub mod error;
 /// Implementations for each language converter
 pub mod language;
 /// Parsing Rust code into a format the `language` modules can understand
@@ -21,7 +22,7 @@ pub use rename::RenameExt;
 #[allow(missing_docs)]
 pub enum ProcessInputError {
     #[error("a parsing error occurred: {0}")]
-    ParseError(#[from] parser::ParseError),
+    ParseError(#[from] error::ParseError),
     #[error("a type generation error occurred: {0}")]
     IoError(#[from] std::io::Error),
 }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     context::{ParseContext, ParseFileContext},
-    error::{ParseError, ParseErrorWithSpan},
+    error::{ParseError, ParseErrorWithSpan, WithSpan as _},
     language::{CrateName, SupportedLanguage},
     rename::RenameExt,
     rust_types::{
@@ -225,10 +225,9 @@ pub(crate) fn parse_struct(
                         RustType::try_from(&f.ty)?
                     };
 
-                    ParseError::ensure(!serde_flatten(&f.attrs), || {
-                        ParseError::SerdeFlattenNotAllowed.with_span(f.span())
-                    })?;
-
+                    if serde_flatten(&f.attrs) {
+                        return Err(ParseError::SerdeFlattenNotAllowed.with_span(f.span()));
+                    }
                     let has_default = serde_default(&f.attrs);
                     let decorators = get_field_decorators(&f.attrs);
 

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -7,7 +7,7 @@ use syn::spanned::Spanned;
 use syn::{Expr, ExprLit, Lit, TypeArray, TypeSlice};
 use thiserror::Error;
 
-use crate::error::{ParseErrorWithSpan, RustTypeParseError};
+use crate::error::{ParseErrorWithSpan, RustTypeParseError, WithSpan as _};
 use crate::language::SupportedLanguage;
 use crate::parser::DecoratorKind;
 use crate::visitors::accept_type;

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use quote::ToTokens;
 use std::collections::BTreeSet;
 use std::fmt::Display;
@@ -8,7 +7,7 @@ use syn::spanned::Spanned;
 use syn::{Expr, ExprLit, Lit, TypeArray, TypeSlice};
 use thiserror::Error;
 
-use crate::error::ParseErrorWithSpan;
+use crate::error::{ParseErrorWithSpan, RustTypeParseError};
 use crate::language::SupportedLanguage;
 use crate::parser::DecoratorKind;
 use crate::visitors::accept_type;
@@ -312,19 +311,6 @@ impl Display for SpecialRustType {
         };
         write!(f, "{special_type}")
     }
-}
-
-#[derive(Debug, Error)]
-#[allow(missing_docs)]
-pub enum RustTypeParseError {
-    #[error("Unsupported type: \"{}\"", .0.iter().join(","))]
-    UnsupportedType(Vec<String>),
-    #[error("Unexpected token when parsing type: `{0}`. This is an internal error, please ping a typeshare developer to resolve this problem.")]
-    UnexpectedToken(String),
-    #[error("Tuples are not allowed in typeshare types")]
-    UnexpectedParameterizedTuple,
-    #[error("Could not parse numeric literal")]
-    NumericLiteral(syn::parse::Error),
 }
 
 impl FromStr for RustType {

--- a/core/src/rust_types.rs
+++ b/core/src/rust_types.rs
@@ -317,7 +317,7 @@ impl Display for SpecialRustType {
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum RustTypeParseError {
-    #[error("Unsupported type: {}", .0.iter().join(","))]
+    #[error("Unsupported type: \"{}\"", .0.iter().join(","))]
     UnsupportedType(Vec<String>),
     #[error("Unexpected token when parsing type: `{0}`. This is an internal error, please ping a typeshare developer to resolve this problem.")]
     UnexpectedToken(String),

--- a/core/src/visitors.rs
+++ b/core/src/visitors.rs
@@ -1,10 +1,11 @@
 //! Visitors to collect various items from the AST.
 use crate::{
     context::ParseContext,
+    error::ParseErrorWithSpan,
     language::CrateName,
     parser::{
         has_typeshare_annotation, parse_const, parse_enum, parse_struct, parse_type_alias,
-        ErrorInfo, ParseError, ParsedData,
+        ErrorInfo, ParsedData,
     },
     rust_types::{RustEnumVariant, RustItem},
     target_os_check::accept_target_os,
@@ -83,12 +84,12 @@ impl<'a> TypeShareVisitor<'a> {
     }
 
     #[inline]
-    fn collect_result(&mut self, result: Result<RustItem, ParseError>) {
+    fn collect_result(&mut self, result: Result<RustItem, ParseErrorWithSpan>) {
         match result {
             Ok(data) => self.parsed_data.push(data),
             Err(error) => self.parsed_data.errors.push(ErrorInfo {
                 file_name: self.file_path.to_string_lossy().into_owned(),
-                error,
+                error: error.to_string(),
             }),
         }
     }

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -61,7 +61,7 @@ mod blocklisted_types {
         .unwrap_err();
         assert_eq!(
             error.to_string(),
-            format!("Failed to parse a rust type: Unsupported type: \"{blocklisted_type}\", on line 5 and column {column}")
+            format!("Failed to parse a Rust type: Unsupported type: \"{blocklisted_type}\", on line 5 and column {column}")
         );
     }
 

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -1,21 +1,21 @@
+use anyhow::anyhow;
 use std::io::Write;
 use typeshare_core::{
     context::{ParseContext, ParseFileContext},
     language::{CrateTypes, Language, TypeScript},
-    parser::{self, ParseError},
-    rust_types::RustTypeParseError,
-    ProcessInputError,
+    parser::{self},
 };
+
 /// Parse and generate types for a single Rust input file.
 pub fn process_input(
     input: &str,
     language: &mut dyn Language,
     imports: &CrateTypes,
     out: &mut dyn Write,
-) -> Result<(), ProcessInputError> {
+) -> anyhow::Result<()> {
     let parse_context = ParseContext::default();
 
-    let mut parsed_data = parser::parse(
+    let parsed_data = parser::parse(
         &parse_context,
         ParseFileContext {
             source_code: input.to_string(),
@@ -23,13 +23,12 @@ pub fn process_input(
             file_name: "file_name".into(),
             file_path: "file_path".into(),
         },
-    )?
+    )
+    .map_err(|err| err.error)?
     .unwrap();
 
     if !parsed_data.errors.is_empty() {
-        return Err(ProcessInputError::ParseError(
-            parsed_data.errors.remove(0).error,
-        ));
+        return Err(anyhow!("{}", parsed_data.errors[0].error));
     }
 
     language.generate_types(out, imports, parsed_data)?;
@@ -41,7 +40,7 @@ mod blocklisted_types {
 
     use super::*;
 
-    fn assert_type_is_blocklisted(ty: &str, blocklisted_type: &str) {
+    fn assert_type_is_blocklisted(ty: &str, blocklisted_type: &str, column: &str) {
         let source = format!(
             r##"
     #[typeshare]
@@ -53,47 +52,52 @@ mod blocklisted_types {
         );
 
         let mut out: Vec<u8> = Vec::new();
-        assert!(matches!(
-            process_input(&source, &mut TypeScript::default(), &HashMap::new(), &mut out),
-            Err(ProcessInputError::ParseError(
-                ParseError::RustTypeParseError(RustTypeParseError::UnsupportedType(contents))
-            )) if contents == vec![blocklisted_type.to_owned()]
-        ));
+        let error = process_input(
+            &source,
+            &mut TypeScript::default(),
+            &HashMap::new(),
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("Failed to parse a rust type: Unsupported type: {blocklisted_type}, line 5, column {column}")
+        );
     }
 
     #[test]
     fn test_i64_blocklisted_struct() {
-        assert_type_is_blocklisted("i64", "i64");
+        assert_type_is_blocklisted("i64", "i64", "17");
     }
 
     #[test]
     fn test_u64_blocklisted_struct() {
-        assert_type_is_blocklisted("u64", "u64");
+        assert_type_is_blocklisted("u64", "u64", "17");
     }
 
     #[test]
     fn test_isize_blocklisted_struct() {
-        assert_type_is_blocklisted("isize", "isize");
+        assert_type_is_blocklisted("isize", "isize", "17");
     }
 
     #[test]
     fn test_usize_blocklisted_in_struct() {
-        assert_type_is_blocklisted("usize", "usize");
+        assert_type_is_blocklisted("usize", "usize", "17");
     }
 
     #[test]
     fn test_optional_blocklisted_struct() {
-        assert_type_is_blocklisted("Option<i64>", "i64");
+        assert_type_is_blocklisted("Option<i64>", "i64", "24");
     }
 
     #[test]
     fn test_vec_blocklisted_struct() {
-        assert_type_is_blocklisted("Vec<i64>", "i64");
+        assert_type_is_blocklisted("Vec<i64>", "i64", "21");
     }
 
     #[test]
     fn test_hashmap_blocklisted_struct() {
-        assert_type_is_blocklisted("HashMap<String, i64>", "i64");
+        assert_type_is_blocklisted("HashMap<String, i64>", "i64", "33");
     }
 }
 
@@ -114,10 +118,17 @@ mod serde_attributes_on_enums {
     "##;
 
         let mut out: Vec<u8> = Vec::new();
-        assert!(matches!(
-            process_input(source, &mut TypeScript::default(), &HashMap::new(), &mut out).unwrap_err(),
-            ProcessInputError::ParseError(ParseError::SerdeContentNotAllowed { enum_ident }) if enum_ident == "Foo"
-        ));
+        let err = process_input(
+            source,
+            &mut TypeScript::default(),
+            &HashMap::new(),
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The serde content attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+        );
     }
 
     #[test]
@@ -132,10 +143,17 @@ mod serde_attributes_on_enums {
     "##;
 
         let mut out: Vec<u8> = Vec::new();
-        assert!(matches!(
-            process_input(source, &mut TypeScript::default(), &HashMap::new(), &mut out).unwrap_err(),
-            ProcessInputError::ParseError(ParseError::SerdeTagNotAllowed { enum_ident }) if enum_ident == "Foo"
-        ));
+        let err = process_input(
+            source,
+            &mut TypeScript::default(),
+            &HashMap::new(),
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The serde tag attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+        );
     }
 
     #[test]
@@ -150,9 +168,16 @@ mod serde_attributes_on_enums {
     "##;
 
         let mut out: Vec<u8> = Vec::new();
-        assert!(matches!(
-            process_input(source, &mut TypeScript::default(), &HashMap::new(), &mut out).unwrap_err(),
-            ProcessInputError::ParseError(ParseError::SerdeTagNotAllowed { enum_ident }) if enum_ident == "Foo"
-        ));
+        let err = process_input(
+            source,
+            &mut TypeScript::default(),
+            &HashMap::new(),
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The serde tag attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+        );
     }
 }

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -61,7 +61,7 @@ mod blocklisted_types {
         .unwrap_err();
         assert_eq!(
             error.to_string(),
-            format!("Failed to parse a rust type: Unsupported type: {blocklisted_type}, line 5, column {column}")
+            format!("Failed to parse a rust type: Unsupported type: \"{blocklisted_type}\", on line 5 and column {column}")
         );
     }
 
@@ -102,9 +102,8 @@ mod blocklisted_types {
 }
 
 mod serde_attributes_on_enums {
-    use std::collections::HashMap;
-
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn content_not_allowed_on_non_algebraic() {
@@ -127,7 +126,7 @@ mod serde_attributes_on_enums {
         .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "The serde content attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+            "The serde content attribute is not supported for non-algebraic enums: Foo, on line 2 and column 4"
         );
     }
 
@@ -152,7 +151,7 @@ mod serde_attributes_on_enums {
         .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "The serde tag attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+            "The serde tag attribute is not supported for non-algebraic enums: Foo, on line 2 and column 4"
         );
     }
 
@@ -177,7 +176,31 @@ mod serde_attributes_on_enums {
         .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "The serde tag attribute is not supported for non-algebraic enums: Foo, line 2, column 4"
+            "The serde tag attribute is not supported for non-algebraic enums: Foo, on line 2 and column 4"
+        );
+    }
+
+    #[test]
+    fn no_flatten() {
+        let source = r##"
+        #[typeshare]
+        pub struct Foo {
+            #[serde(flatten)]
+            pub field1: HashMap<String, String>
+        }
+        "##;
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = process_input(
+            source,
+            &mut TypeScript::default(),
+            &HashMap::new(),
+            &mut out,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "The serde flatten attribute is not currently supported, on line 4 and column 12"
         );
     }
 }

--- a/core/tests/agnostic_tests.rs
+++ b/core/tests/agnostic_tests.rs
@@ -24,7 +24,7 @@ pub fn process_input(
             file_path: "file_path".into(),
         },
     )
-    .map_err(|err| err.error)?
+    .map_err(|err| anyhow!("Failed to parse {err}"))?
     .unwrap();
 
     if !parsed_data.errors.is_empty() {

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -121,17 +121,7 @@ fn check(
     })?
     .unwrap();
 
-    let all_crates: CrateName = String::new().into()
-        
-        
-        
-        
-        
-        
-        
-        
-        
-;
+    let all_crates: CrateName = String::new().into();
 
     let mut map = BTreeMap::from_iter([(all_crates.clone(), parsed_data)]);
     reconcile_aliases(&mut map);

--- a/core/tests/snapshot_tests.rs
+++ b/core/tests/snapshot_tests.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use anyhow::Context;
 use flexi_logger::DeferredNow;
 use log::Record;
@@ -83,7 +84,7 @@ fn load_file(path: impl AsRef<Path>) -> Result<String, anyhow::Error> {
 /// folder if they do not exist.
 fn check(
     test_name: &str,
-    file_name: impl AsRef<Path>,
+    file_name: impl AsRef<Path> + std::fmt::Debug,
     mut lang: Box<dyn Language>,
     target_os: &[&str],
 ) -> Result<(), anyhow::Error> {
@@ -110,18 +111,39 @@ fn check(
         ParseFileContext {
             source_code: rust_input,
             crate_name: "default_crate".into(),
-            file_name: "file_name".into(),
-            file_path: "file_path".into(),
+            file_name: file_name.as_ref().to_string_lossy().to_string(),
+            file_path: file_name.as_ref().into(),
         },
-    )?
+    )
+    .map_err(|err| anyhow!("Parsing failed: {:?},  {err}", file_name))
+    .inspect_err(|err| {
+        eprintln!("Error: {err}");
+    })?
     .unwrap();
 
-    let all_crates: CrateName = String::new().into();
+    let all_crates: CrateName = String::new().into()
+        
+        
+        
+        
+        
+        
+        
+        
+        
+;
 
     let mut map = BTreeMap::from_iter([(all_crates.clone(), parsed_data)]);
     reconcile_aliases(&mut map);
 
     let parsed_data = map.remove(&all_crates).unwrap();
+
+    if !parsed_data.errors.is_empty() {
+        for error in &parsed_data.errors {
+            eprintln!("Parsing failed: {error:?}");
+        }
+        panic!("Errors during parsing");
+    }
 
     lang.generate_types(&mut typeshare_output, &HashMap::new(), parsed_data)?;
 


### PR DESCRIPTION
It is useful to capture the line and column numbers when parsing rejects the Rust source code. 

This MR uses `Span` to capture this data. The error handling could be reworked some more but this allows capturing the line, column numbers without too many changes.

This was requested in #260 

Example test invalid type parse error:

```
cat /tmp/typeshare-test/src/test.rs
//! This is a module comment

#[typeshare]
pub struct MyType {
    pub field: usize
}
```

Running from the command line.
```
cargo run --bin typeshare -- -l typescript -d /tmp/out /tmp/typeshare-test
   Compiling typeshare-core v1.13.3 (/home/droberts/projects/typeshare/core)
   Compiling typeshare-cli v1.13.3 (/home/droberts/projects/typeshare/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.84s
     Running `target/debug/typeshare -l typescript -d /tmp/out /tmp/typeshare-test`
[2025-08-02 17:25:09.911115 -04:00] INFO [cli/src/main.rs:78] typeshare started generating types
[2025-08-02 17:25:09.911217 -04:00] INFO [cli/src/main.rs:85] Using directories: ["/tmp/typeshare-test"]
[2025-08-02 17:25:09.918404 -04:00] ERROR [cli/src/main.rs:296] Parsing error: "Failed to parse a Rust type: Unsupported type: "usize", on line 5 and column 15" in file "/tmp/typeshare-test/src/test.rs"
[2025-08-02 17:25:09.918466 -04:00] ERROR [cli/src/main.rs:304] Errors encountered during parsing.
[2025-08-02 17:25:09.918505 -04:00] ERROR [cli/src/main.rs:72] typeshare failed to generate types: Errors encountered during parsing.
Error: Errors encountered during parsing.
```

Notable parse error with file, line and column number:

Parsing error: "Failed to parse a Rust type: Unsupported type: "usize", on line 5 and column 15" in file "/tmp/typeshare-test/src/test.rs"

