### PR TITLE
Add automated job to update flake.lock file

### DIFF
--- a/.github/workflows/update_flake_lock.yml
+++ b/.github/workflows/update_flake_lock.yml
@@ -1,0 +1,19 @@
+name: "Check for updates to Nix flake.lock file"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # runs weekly on Sunday at midnight
+
+jobs:
+  nix-flake-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock file with latest versions"
+          pr-labels: |
+            dependencies
+            automated


### PR DESCRIPTION
Info
-----
* The example `flake.lock` file we had was out of date and causing potential issues.
* That was manually fixed in #263, however to prevent it getting out of date again, we should automate any future updates.
* The action https://github.com/DeterminateSystems/update-flake-lock provides exactly what we are looking for - automated creation of PRs to bump `flake.lock`

Changes
-----
* Used the example from `update-flake-lock` to create an automated job that will create a PR whenever there are updates to `flake.lock` necessary