### PR TITLE
Add automated job to update flake.lock file with signed commits

### DIFF
--- a/.github/workflows/update_flake_lock.yml
+++ b/.github/workflows/update_flake_lock.yml
@@ -1,0 +1,26 @@
+name: "Check for updates to Nix flake.lock file"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # runs weekly on Sunday at midnight
+
+jobs:
+  nix-flake-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock file with latest versions"
+          pr-labels: |
+            dependencies
+            automated
+          git-author-name: ${{ secrets.OP_BOT_COMMIT_NAME }}
+          git-author-email: ${{ secrets.OP_BOT_COMMIT_EMAIL }}
+          git-committer-name: ${{ secrets.OP_BOT_COMMIT_NAME }}
+          git-committer-email: ${{ secrets.OP_BOT_COMMIT_EMAIL }}
+          sign-commits: true
+          gpg-private-key: ${{ secrets.OP_BOT_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.OP_BOT_GPG_PASSPHRASE }}


### PR DESCRIPTION
Info
-----
* Second attempt at an automated job to update `flake.lock`, after #264
* The original job worked, but the PR created did not have signed commits, so it wasn't mergeable.
* This approach adds a GPG key and associates the commits with @1password-bot (which is already used in other repos within the org)

Changes
-----
* The job is created the same way as the previous PR, however we now add the author, committer, and GPG key information using repo secrets.

Testing
-----
* We discovered in the last PR that testing via a PR-triggered job did not work as expected, so we'll likely need some quick follow-up testing once this is merged.